### PR TITLE
Add support for client credentials oauth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
   "size-limit": [
     {
       "path": "dist/react-vault.cjs.production.min.js",
-      "limit": "100 KB"
+      "limit": "200 KB"
     },
     {
       "path": "dist/react-vault.esm.js",
-      "limit": "100 KB"
+      "limit": "200 KB"
     }
   ],
   "resolutions": {

--- a/src/components/AuthorizeButton.tsx
+++ b/src/components/AuthorizeButton.tsx
@@ -28,7 +28,10 @@ const AuthorizeButton = ({ connection }: Props) => {
 
   const authorizeConnection = async () => {
     setIsLoading(true);
-    if (connection.oauth_grant_type === 'client_credentials') {
+    if (
+      connection.oauth_grant_type === 'client_credentials' ||
+      connection.oauth_grant_type === 'password'
+    ) {
       try {
         const response: any = await fetch(
           `${connectionsUrl}/${connection.unified_api}/${connection.service_id}/token`,

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -28,66 +28,68 @@ export function ConfirmModal({ onClose, isOpen = false, onConfirm }: Props) {
         className="fixed inset-0 z-40 overflow-y-auto"
         onClose={onClose}
       >
-        <div className="min-h-screen px-4 text-center">
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <Dialog.Overlay className="fixed inset-0" />
-          </Transition.Child>
+        <div id="react-vault">
+          <div className="min-h-screen px-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0"
+              enterTo="opacity-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Dialog.Overlay className="fixed inset-0" />
+            </Transition.Child>
 
-          {/* This element is to trick the browser into centering the modal contents. */}
-          <span
-            className="inline-block h-screen align-middle"
-            aria-hidden="true"
-          >
-            &#8203;
-          </span>
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0 scale-95"
-            enterTo="opacity-100 scale-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100 scale-100"
-            leaveTo="opacity-0 scale-95"
-          >
-            <div className="inline-block w-full max-w-xs p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
-              <Dialog.Title
-                as="h3"
-                className="text-lg font-medium leading-6 text-gray-900"
-              >
-                Are you sure?
-              </Dialog.Title>
-              <div className="mt-2">
-                <p className="text-sm text-gray-500">
-                  When you delete a connection you will lose all your configured
-                  settings.
-                </p>
-              </div>
+            {/* This element is to trick the browser into centering the modal contents. */}
+            <span
+              className="inline-block h-screen align-middle"
+              aria-hidden="true"
+            >
+              &#8203;
+            </span>
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <div className="inline-block w-full max-w-xs p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+                <Dialog.Title
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Are you sure?
+                </Dialog.Title>
+                <div className="mt-2">
+                  <p className="text-sm text-gray-500">
+                    When you delete a connection you will lose all your
+                    configured settings.
+                  </p>
+                </div>
 
-              <div className="mt-4 space-x-4 flex">
-                <Button
-                  onClick={handleConfirm}
-                  text="Delete"
-                  variant="danger"
-                  className="w-full"
-                  isLoading={isLoading}
-                />
-                <Button
-                  onClick={onClose}
-                  text="Cancel"
-                  variant="outline"
-                  className="w-full"
-                />
+                <div className="mt-4 space-x-4 flex">
+                  <Button
+                    onClick={handleConfirm}
+                    text="Delete"
+                    variant="danger"
+                    className="w-full"
+                    isLoading={isLoading}
+                  />
+                  <Button
+                    onClick={onClose}
+                    text="Cancel"
+                    variant="outline"
+                    className="w-full"
+                  />
+                </div>
               </div>
-            </div>
-          </Transition.Child>
+            </Transition.Child>
+          </div>
         </div>
       </Dialog>
     </Transition>

--- a/src/components/ConnectionDetails.tsx
+++ b/src/components/ConnectionDetails.tsx
@@ -47,13 +47,14 @@ const ConnectionDetails = ({ onClose }: Props) => {
   // TODO: implement hideResourceSettings from session
   const [showResources, setShowResources] = useState(false);
 
-  const requiredAuth = authorizationVariablesRequired(selectedConnection);
+  const requiredAuthVariables =
+    authorizationVariablesRequired(selectedConnection);
 
   const shouldShowAuthorizeButton =
     enabled &&
     state !== 'callable' &&
     auth_type === 'oauth2' &&
-    !requiredAuth &&
+    !requiredAuthVariables &&
     !showSettings;
 
   useEffect(() => {
@@ -63,7 +64,7 @@ const ConnectionDetails = ({ onClose }: Props) => {
       enabled &&
       state !== 'callable' &&
       hasFormFields &&
-      !shouldShowAuthorizeButton
+      (!shouldShowAuthorizeButton || state === 'authorized')
     ) {
       setShowSettings(true);
     }
@@ -176,9 +177,9 @@ const ConnectionDetails = ({ onClose }: Props) => {
 
           {hasFormFields && showSettings ? (
             <Fragment>
-              {requiredAuth ? (
+              {requiredAuthVariables ? (
                 <div className={'mt-4 text-xs sm:text-sm text-gray-700'}>
-                  {requiredAuth}
+                  {requiredAuthVariables}
                 </div>
               ) : null}
               <Divider text="Settings" />

--- a/src/components/ConnectionForm.tsx
+++ b/src/components/ConnectionForm.tsx
@@ -1,5 +1,5 @@
 import { Button, TextInput } from '@apideck/components';
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { Dispatch, Fragment, SetStateAction } from 'react';
 
 import { Connection } from '../types/Connection';
 import Markdown from 'markdown-to-jsx';
@@ -41,82 +41,128 @@ const ConnectionForm = ({ connection, setShowSettings }: Props) => {
   });
 
   return (
-    <form
-      className="space-y-4 text-left"
-      onSubmit={formik.handleSubmit}
-      id="react-vault-connection-form"
-      data-testid="connection-form"
-    >
-      {filteredFormFields.map((field, i) => {
-        const {
-          id,
-          label,
-          required,
-          placeholder,
-          description,
-          disabled,
-          type,
-          options,
-          sensitive,
-          allow_custom_values: allowCustomValues,
-        } = field;
-        return (
-          <div key={i}>
-            <label
-              htmlFor={id}
-              className="block text-sm font-medium text-gray-700"
-            >
-              {label}
-              {required && <span className="ml-1 text-red-600">*</span>}
-            </label>
-            <div className="mt-1">
-              {(type === 'text' || type === 'password') && (
-                <TextInput
-                  name={id}
-                  type="text"
-                  required={required}
-                  placeholder={placeholder}
-                  onChange={formik.handleChange}
-                  disabled={disabled}
-                  value={formik.values[id] as any}
-                  data-testid={id}
-                  sensitive={type === 'password' || sensitive}
-                  canBeCopied={type === 'password' || sensitive}
-                />
-              )}
-              {type === 'select' && (
-                <SearchSelect
-                  field={id}
-                  handleChange={formik.handleChange}
-                  disabled={disabled}
-                  value={formik.values[id] as any}
-                  options={options as any}
-                  placeholder={
-                    disabled
-                      ? 'Available after authorization'
-                      : placeholder || 'Select..'
-                  }
-                  isCreatable={allowCustomValues}
-                />
-              )}
-              {description && (
-                <small className="inline-block mt-2 text-gray-600 overflow-x-auto truncate w-full">
-                  <Markdown>{description}</Markdown>
-                </small>
-              )}
+    <Fragment>
+      <form
+        className="space-y-4 text-left"
+        onSubmit={formik.handleSubmit}
+        id="react-vault-connection-form"
+        data-testid="connection-form"
+      >
+        {filteredFormFields.map((field, i) => {
+          const {
+            id,
+            label,
+            required,
+            placeholder,
+            description,
+            disabled,
+            type,
+            options,
+            sensitive,
+            allow_custom_values: allowCustomValues,
+          } = field;
+          return (
+            <div key={i}>
+              <label
+                htmlFor={id}
+                className="block text-sm font-medium text-gray-700"
+              >
+                {label}
+                {required && <span className="ml-1 text-red-600">*</span>}
+              </label>
+              <div className="mt-1">
+                {(type === 'text' || type === 'password') && (
+                  <TextInput
+                    name={id}
+                    type="text"
+                    required={required}
+                    placeholder={placeholder}
+                    onChange={formik.handleChange}
+                    disabled={disabled}
+                    value={formik.values[id] as any}
+                    data-testid={id}
+                    sensitive={type === 'password' || sensitive}
+                    canBeCopied={type === 'password' || sensitive}
+                  />
+                )}
+                {type === 'select' && (
+                  <SearchSelect
+                    field={id}
+                    handleChange={formik.handleChange}
+                    disabled={disabled}
+                    value={formik.values[id] as any}
+                    options={options as any}
+                    placeholder={
+                      disabled
+                        ? 'Available after authorization'
+                        : placeholder || 'Select..'
+                    }
+                    isCreatable={allowCustomValues}
+                  />
+                )}
+                {description && (
+                  <small className="inline-block mt-2 text-gray-600 overflow-x-auto truncate w-full">
+                    <Markdown>{description}</Markdown>
+                  </small>
+                )}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
 
-      <Button
-        type="submit"
-        text="Save"
-        isLoading={isUpdating}
-        size="large"
-        className="w-full"
-      />
-    </form>
+        <Button
+          type="submit"
+          text="Save"
+          isLoading={isUpdating}
+          size="large"
+          className="w-full"
+        />
+      </form>
+      {connection.has_guide && (
+        <div className="flex text-sm items-center text-gray-600 round-b-xl py-3 px-5 md:px-6 bg-gray-100 -mx-5 md:-mx-6 -mb-5 md:-mb-6 mt-4 border-t border-gray-200">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            className="w-5 h-5 mr-1"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+            />
+          </svg>
+
+          <span>
+            Need help? View our{' '}
+            <a
+              className="inline-flex items-center text-main hover:text-main underline font-semibold hover:text-primary-600 transition"
+              target="_blank"
+              rel="noreferrer"
+              href={`https://developers.apideck.com/connectors/${connection.service_id}/docs/consumer+connection`}
+            >
+              Connection Guide
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                className="w-4 h-4 ml-1"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+                />
+              </svg>
+            </a>
+          </span>
+        </div>
+      )}
+    </Fragment>
   );
 };
 

--- a/src/components/ConnectionForm.tsx
+++ b/src/components/ConnectionForm.tsx
@@ -100,7 +100,7 @@ const ConnectionForm = ({ connection, setShowSettings }: Props) => {
                 />
               )}
               {description && (
-                <small className="inline-block mt-2 text-gray-600">
+                <small className="inline-block mt-2 text-gray-600 overflow-x-auto truncate w-full">
                   <Markdown>{description}</Markdown>
                 </small>
               )}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -296,7 +296,7 @@ const TopBar = ({
   };
 
   return (
-    <div className="grid grid-cols-3 px-6" id="react-vault-top-bar">
+    <div className="grid grid-cols-3 px-6 relative" id="react-vault-top-bar">
       <ConfirmModal
         isOpen={showDeleteModal}
         onClose={() => setShowDeleteModal(false)}

--- a/src/types/Connection.ts
+++ b/src/types/Connection.ts
@@ -36,4 +36,5 @@ export interface Connection {
   created_at: number;
   resources?: { id: string; config: any }[];
   oauth_grant_type?: OauthGrantType;
+  has_guide?: boolean;
 }

--- a/src/types/Connection.ts
+++ b/src/types/Connection.ts
@@ -11,6 +11,8 @@ export interface Settings extends RawJSON {
 
 export type ConnectionState = 'available' | 'added' | 'authorized' | 'callable';
 
+export type OauthGrantType = 'client_credentials' | 'authorization_code';
+
 export interface Connection {
   id: string;
   service_id: string;
@@ -33,4 +35,5 @@ export interface Connection {
   form_fields: FormField[];
   created_at: number;
   resources?: { id: string; config: any }[];
+  oauth_grant_type?: OauthGrantType;
 }

--- a/src/types/Connection.ts
+++ b/src/types/Connection.ts
@@ -11,7 +11,10 @@ export interface Settings extends RawJSON {
 
 export type ConnectionState = 'available' | 'added' | 'authorized' | 'callable';
 
-export type OauthGrantType = 'client_credentials' | 'authorization_code';
+export type OauthGrantType =
+  | 'client_credentials'
+  | 'authorization_code'
+  | 'password';
 
 export interface Connection {
   id: string;

--- a/src/utils/useConnections.tsx
+++ b/src/utils/useConnections.tsx
@@ -26,6 +26,7 @@ interface ContextProps {
   singleConnectionMode: boolean;
   sessionExpired: boolean;
   connectionsUrl: string;
+  headers: any;
   updateConnection: (
     api: string,
     serviceId: string,
@@ -69,20 +70,19 @@ export const ConnectionsProvider = ({
   const singleConnectionMode =
     unifiedApi?.length && serviceId?.length ? true : false;
 
-  const getHeaders = () => {
-    return {
+  const headers = useMemo(
+    () => ({
       Authorization: `Bearer ${token}`,
       'X-APIDECK-APP-ID': appId,
       'X-APIDECK-CONSUMER-ID': consumerId,
       'X-APIDECK-AUTH-TYPE': 'JWT',
       'Content-Type': 'application/json',
-    };
-  };
+    }),
+    [token, appId, consumerId]
+  );
 
   const fetcher = async (url: string) => {
-    const response = await fetch(url, {
-      headers: getHeaders(),
-    });
+    const response = await fetch(url, { headers });
     return await response.json();
   };
 
@@ -155,7 +155,7 @@ export const ConnectionsProvider = ({
 
       const response = await fetch(updateUrl, {
         method: 'PATCH',
-        headers: getHeaders(),
+        headers,
         body: JSON.stringify(values),
       });
       const result = await response.json();
@@ -224,7 +224,7 @@ export const ConnectionsProvider = ({
         `${connectionsUrl}/${connection.unified_api}/${connection.service_id}`,
         {
           method: 'DELETE',
-          headers: getHeaders(),
+          headers,
         }
       );
       const updatedConnection = {
@@ -259,9 +259,7 @@ export const ConnectionsProvider = ({
     if (!selectedConnection) return;
     const raw = await fetch(
       `${connectionsUrl}/${selectedConnection.unified_api}/${selectedConnection.service_id}/${resource}/config`,
-      {
-        headers: getHeaders(),
-      }
+      { headers }
     );
     const response = await raw.json();
 
@@ -320,6 +318,7 @@ export const ConnectionsProvider = ({
       singleConnectionMode,
       updateConnection,
       connectionsUrl,
+      headers,
     }),
     [
       isUpdating,


### PR DESCRIPTION
#31: Adds support for client credentials OAuth flow. Same implementation as in Hosted Vault. 

Here is an example of how to connect Sage Intact, which has
1) Required fields before authorizing
2) OAuth grant type of `client_credentials`
3) Required field after authorizing

https://user-images.githubusercontent.com/17762366/193814308-18819aa7-78bc-4c82-9e83-2d95c429b314.mp4


#56:  Adds link to guide if present 

![CleanShot 2022-10-06 at 10 35 02](https://user-images.githubusercontent.com/17762366/194263733-1d811eff-495a-46c2-bc90-780d1d78eca4.png)

