### PR TITLE
Fix Vault config requests

### DIFF
--- a/src/utils/useConnections.tsx
+++ b/src/utils/useConnections.tsx
@@ -187,7 +187,7 @@ export const ConnectionsProvider = ({
         mutate(updateUrl, updatedDetail, false);
         setSelectedConnection({ ...selectedConnection, ...result.data });
 
-        if (resource) getResourceConfig();
+        if (resource) await getResourceConfig();
 
         const message = values.hasOwnProperty('enabled')
           ? `${result.data?.name} is ${values.enabled ? 'enabled' : 'disabled'}`
@@ -286,6 +286,13 @@ export const ConnectionsProvider = ({
       const errorResponse: any = responses.find((res: any) => res.error);
       if (errorResponse) {
         console.error('Failed to fetch resource config', errorResponse);
+        addToast({
+          title: 'Failed to fetch resource config',
+          description: `${errorResponse?.message} ${errorResponse?.detail?.error?.[0]?.message}`,
+          type: 'error',
+          autoClose: false,
+        });
+        setResources(responses);
         return;
       }
       setResources(responses);


### PR DESCRIPTION
Adds a toast message with the error response and stops from retrying the API requests.

Linked to #70 