### PR TITLE
Add copy and info field types with dynamic description interpolation

### DIFF
--- a/src/components/ConnectionForm.tsx
+++ b/src/components/ConnectionForm.tsx
@@ -261,7 +261,7 @@ const ConnectionForm = ({ connection, setCurrentView, settings }: Props) => {
                   />
                 )}
                 {type === 'info' && description && (
-                  <div className="markdown text-sm text-gray-600 overflow-x-auto w-full">
+                  <div className="markdown markdown-info">
                     <Markdown>
                       {interpolateDescription(description, formFields)}
                     </Markdown>

--- a/src/components/ConnectionForm.tsx
+++ b/src/components/ConnectionForm.tsx
@@ -17,6 +17,15 @@ import { useSession } from '../utils/useSession';
 import { Markdown } from './Markdown';
 import SearchSelect from './SearchSelect';
 
+const interpolateDescription = (
+  description: string,
+  fields: Connection['form_fields']
+): string =>
+  description.replace(/\{\{(\w+)\}\}/g, (_, id) => {
+    const value = fields?.find((f) => f.id === id)?.value;
+    return value == null ? '' : String(value);
+  });
+
 interface Props {
   connection: Connection;
   setCurrentView: Dispatch<
@@ -216,6 +225,16 @@ const ConnectionForm = ({ connection, setCurrentView, settings }: Props) => {
                     sensitive={type === 'password' || sensitive}
                   />
                 )}
+                {type === 'copy' && (
+                  <TextInput
+                    name={id}
+                    type="text"
+                    disabled
+                    canBeCopied
+                    value={(formik.values[id] as any) ?? ''}
+                    data-testid={id}
+                  />
+                )}
                 {type === 'textarea' && (
                   <TextArea
                     name={id}
@@ -241,9 +260,18 @@ const ConnectionForm = ({ connection, setCurrentView, settings }: Props) => {
                     isMulti={type === 'multi-select'}
                   />
                 )}
-                {description && (
+                {type === 'info' && description && (
+                  <div className="markdown text-sm text-gray-600 overflow-x-auto w-full">
+                    <Markdown>
+                      {interpolateDescription(description, formFields)}
+                    </Markdown>
+                  </div>
+                )}
+                {type !== 'info' && description && (
                   <small className="markdown inline-block mt-2 text-gray-500 overflow-x-auto w-full">
-                    <Markdown>{description}</Markdown>
+                    <Markdown>
+                      {interpolateDescription(description, formFields)}
+                    </Markdown>
                   </small>
                 )}
               </div>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -470,6 +470,82 @@ body {
   @apply text-gray-600 underline;
 }
 
+/* Info-type field blocks (type: "info") */
+.apideck .markdown-info {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background-color: #f9fafb;
+  padding: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: #374151;
+}
+
+.apideck .markdown-info p {
+  margin: 0 0 0.5rem 0;
+}
+
+.apideck .markdown-info p:last-child {
+  margin-bottom: 0;
+}
+
+.apideck .markdown-info a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-weight: 600;
+  color: #111827;
+  text-decoration: none;
+}
+
+.apideck .markdown-info a:hover {
+  color: #374151;
+  text-decoration: underline;
+}
+
+.apideck .markdown-info ol {
+  counter-reset: info-step;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.apideck .markdown-info ol > li {
+  counter-increment: info-step;
+  position: relative;
+  padding-left: 2.25rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.4;
+}
+
+.apideck .markdown-info ol > li:last-child {
+  margin-bottom: 0;
+}
+
+.apideck .markdown-info ol > li::before {
+  content: counter(info-step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 9999px;
+  background-color: #111827;
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.apideck .markdown-info ol > li > strong:first-child {
+  display: block;
+  color: #111827;
+  margin-bottom: 0.125rem;
+}
+
 /* Animations */
 .apideck .fade-in {
   animation: fadeIn 0.2s;

--- a/src/types/FormField.ts
+++ b/src/types/FormField.ts
@@ -20,6 +20,8 @@ export interface FormField {
     | 'date'
     | 'password'
     | 'datetime'
+    | 'copy'
+    | 'info'
     | unknown;
   required: boolean;
   description?: string;

--- a/stories/ConnectionForm.stories.tsx
+++ b/stories/ConnectionForm.stories.tsx
@@ -1,0 +1,198 @@
+import '../src/styles/index.css';
+
+import { Meta, Story } from '@storybook/react';
+import { ToastProvider } from '@apideck/components';
+import React from 'react';
+
+import ConnectionForm from '../src/components/ConnectionForm';
+import { Connection } from '../src/types/Connection';
+
+const baseConnection = {
+  id: 'qbd-demo',
+  name: 'QuickBooks Desktop',
+  service_id: 'quickbooks-desktop',
+  unified_api: 'accounting',
+  auth_type: 'custom',
+  state: 'added',
+  enabled: true,
+  validation_support: false,
+  custom_mappings: [],
+  configuration: [],
+} as unknown as Connection;
+
+interface TemplateArgs {
+  formFields: any[];
+}
+
+const meta: Meta<TemplateArgs> = {
+  title: 'ConnectionForm / Field types',
+};
+export default meta;
+
+const Template: Story<TemplateArgs> = ({ formFields }) => (
+  <ToastProvider>
+    <div
+      className="apideck"
+      style={{
+        maxWidth: 480,
+        margin: '2rem auto',
+        padding: '1.5rem',
+        border: '1px solid #e5e7eb',
+        borderRadius: 8,
+        background: 'white',
+      }}
+    >
+      <ConnectionForm
+        connection={
+          { ...baseConnection, form_fields: formFields } as Connection
+        }
+        setCurrentView={() => {}}
+        settings={{}}
+      />
+    </div>
+  </ToastProvider>
+);
+
+export const CopyField = Template.bind({});
+CopyField.args = {
+  formFields: [
+    {
+      id: 'qbd_password',
+      label: 'Web Connector Password',
+      type: 'copy',
+      value: 'aB3kMnPq7RsTvW2x',
+      description:
+        'Save this password — you will need it when QuickBooks Web Connector prompts you during setup.',
+      disabled: true,
+      required: false,
+      placeholder: '',
+      mask: false,
+      options: [],
+      custom_field: false,
+      hidden: false,
+    },
+  ],
+};
+
+export const InfoField = Template.bind({});
+InfoField.args = {
+  formFields: [
+    {
+      id: 'setup_instructions',
+      label: 'Setup Instructions',
+      type: 'info',
+      value: '',
+      description:
+        '1. **Open QuickBooks Desktop** — make sure your company file is open\n2. **Open Web Connector** — find it in your Start menu or QuickBooks folder\n3. **Click "Add an application"** — select the .qwc file you downloaded\n4. **Authorize in QuickBooks** — click "Yes" when prompted',
+      disabled: false,
+      required: false,
+      placeholder: '',
+      mask: false,
+      options: [],
+      custom_field: false,
+      hidden: false,
+    },
+  ],
+};
+
+export const InterpolationInDescription = Template.bind({});
+InterpolationInDescription.args = {
+  formFields: [
+    {
+      id: 'qwc_download_url',
+      label: '',
+      type: 'text',
+      value:
+        'https://qbd-connect.staging.apideck.com/api/qwc?connectionId=abc_123',
+      description: '',
+      disabled: false,
+      required: false,
+      placeholder: '',
+      mask: false,
+      options: [],
+      custom_field: false,
+      hidden: true,
+    },
+    {
+      id: 'qwc_info',
+      label: 'Web Connector Setup File',
+      type: 'info',
+      value: '',
+      description:
+        '[Download your QWC file]({{qwc_download_url}})\n\nOpen this file with QuickBooks Web Connector to register the connection.',
+      disabled: false,
+      required: false,
+      placeholder: '',
+      mask: false,
+      options: [],
+      custom_field: false,
+      hidden: false,
+    },
+  ],
+};
+
+export const QBDFullSetup = Template.bind({});
+QBDFullSetup.args = {
+  formFields: [
+    {
+      id: 'qbd_password',
+      label: 'Web Connector Password',
+      type: 'copy',
+      value: 'aB3kMnPq7RsTvW2x',
+      description:
+        'Save this password — you will need it when QuickBooks Web Connector prompts you during setup.',
+      disabled: true,
+      required: false,
+      placeholder: '',
+      mask: false,
+      options: [],
+      custom_field: false,
+      hidden: false,
+    },
+    {
+      id: 'qwc_download_url',
+      label: '',
+      type: 'text',
+      value:
+        'https://qbd-connect.staging.apideck.com/api/qwc?connectionId=abc_123',
+      description: '',
+      disabled: false,
+      required: false,
+      placeholder: '',
+      mask: false,
+      options: [],
+      custom_field: false,
+      hidden: true,
+    },
+    {
+      id: 'qwc_setup',
+      label: 'Web Connector Setup File',
+      type: 'info',
+      value: '',
+      description:
+        "[⬇ Download apideck.qwc]({{qwc_download_url}})\n\nSave this file, then add it to QuickBooks Web Connector on your Windows machine by clicking 'Add an Application'.",
+      disabled: false,
+      required: false,
+      placeholder: '',
+      mask: false,
+      options: [],
+      custom_field: false,
+      hidden: false,
+    },
+    {
+      id: 'setup_instructions',
+      label: 'How to set up Web Connector',
+      type: 'info',
+      value: '',
+      description:
+        "1. **Open QuickBooks Desktop** — Make sure your company file is open\n2. **Open Web Connector** — Find it in your Start menu or QuickBooks folder\n3. **Click 'Add an application'** — Select the .qwc file you downloaded\n4. **Authorize in QuickBooks** — Click 'Yes' when prompted to allow access\n5. **Enter the password** — Use the password shown above\n6. **Run the sync** — Check the box and click 'Update Selected'",
+      disabled: false,
+      required: false,
+      placeholder: '',
+      mask: false,
+      options: [],
+      custom_field: false,
+      hidden: false,
+    },
+  ],
+};

--- a/test/connection-form-field-types.test.tsx
+++ b/test/connection-form-field-types.test.tsx
@@ -77,9 +77,10 @@ describe('ConnectionForm - type: "copy" field', () => {
 
   it('renders a copy button next to the input', async () => {
     const screen = await renderForm([copyField]);
-    // canBeCopied renders a button with title "Copy" inside @apideck/components TextInput
-    const copyButton = screen.getByTestId('qbd_password-copy-button');
+    // @apideck/components renders the canBeCopied button with data-testid="copy-button"
+    const copyButton = screen.getByTestId('copy-button');
     expect(copyButton).toBeInTheDocument();
+    expect(copyButton.tagName.toLowerCase()).toBe('button');
   });
 
   it('renders the field label', async () => {
@@ -194,7 +195,11 @@ describe('ConnectionForm - {{field_id}} description interpolation', () => {
         description: 'Visit {{url}}',
       },
     ]);
-    expect(screen.getByText(/Visit https:\/\/example\.com/)).toBeInTheDocument();
+    // markdown-to-jsx autolinks bare URLs, splitting "Visit " from the link text
+    expect(screen.getByText(/Visit/)).toBeInTheDocument();
+    const link = screen.getByText('https://example.com') as HTMLAnchorElement;
+    expect(link.tagName.toLowerCase()).toBe('a');
+    expect(link.getAttribute('href')).toBe('https://example.com');
   });
 
   it('resolves multiple tokens', async () => {

--- a/test/connection-form-field-types.test.tsx
+++ b/test/connection-form-field-types.test.tsx
@@ -1,0 +1,324 @@
+import '@testing-library/jest-dom/extend-expect';
+import 'jest-location-mock';
+import 'whatwg-fetch';
+
+import * as React from 'react';
+
+import { render } from '@testing-library/react';
+import { fetchMock, setupIntersectionObserverMock } from './mock';
+
+import { act } from 'react-dom/test-utils';
+import ConnectionForm from '../src/components/ConnectionForm';
+import { Connection } from '../src/types/Connection';
+import { INVALID_SESSION_RESPONSE } from './responses/invalid-session';
+
+jest.mock('../src/utils/useConnections', () => ({
+  useConnections: () => ({ updateConnection: jest.fn() }),
+}));
+
+const baseConnection: Connection = {
+  id: 'crm+test',
+  name: 'Test',
+  service_id: 'test',
+  unified_api: 'crm',
+  auth_type: 'apiKey',
+  state: 'added',
+  enabled: true,
+  tag_line: '',
+  icon: '',
+  logo: '',
+  website: '',
+  custom_mappings: [],
+  configuration: [],
+  form_fields: [],
+} as unknown as Connection;
+
+const renderForm = async (formFields: any[]) => {
+  let screen: any;
+  await act(async () => {
+    screen = render(
+      <ConnectionForm
+        connection={{ ...baseConnection, form_fields: formFields } as Connection}
+        setCurrentView={() => {}}
+        settings={{}}
+      />
+    );
+  });
+  return screen;
+};
+
+describe('ConnectionForm - type: "copy" field', () => {
+  beforeEach(() => jest.spyOn(window, 'fetch'));
+  beforeEach(() => fetchMock(INVALID_SESSION_RESPONSE));
+  beforeEach(() => setupIntersectionObserverMock());
+
+  const copyField = {
+    id: 'qbd_password',
+    label: 'QBD Password',
+    value: 'aB3kMnPq7RsTvW2x',
+    placeholder: '',
+    mask: false,
+    type: 'copy',
+    required: false,
+    description: 'Generated password for the QBD connection',
+    disabled: true,
+    options: [],
+    custom_field: false,
+    hidden: false,
+  };
+
+  it('renders a disabled TextInput with the field value', async () => {
+    const screen = await renderForm([copyField]);
+    const input = screen.getByTestId('qbd_password') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input).toBeDisabled();
+    expect(input.value).toBe('aB3kMnPq7RsTvW2x');
+  });
+
+  it('renders a copy button next to the input', async () => {
+    const screen = await renderForm([copyField]);
+    // canBeCopied renders a button with title "Copy" inside @apideck/components TextInput
+    const copyButton = screen.getByTestId('qbd_password-copy-button');
+    expect(copyButton).toBeInTheDocument();
+  });
+
+  it('renders the field label', async () => {
+    const screen = await renderForm([copyField]);
+    expect(screen.getByText('QBD Password')).toBeInTheDocument();
+  });
+
+  it('renders the markdown description', async () => {
+    const screen = await renderForm([copyField]);
+    expect(
+      screen.getByText('Generated password for the QBD connection')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('ConnectionForm - type: "info" field', () => {
+  beforeEach(() => jest.spyOn(window, 'fetch'));
+  beforeEach(() => fetchMock(INVALID_SESSION_RESPONSE));
+  beforeEach(() => setupIntersectionObserverMock());
+
+  const baseInfoField = {
+    id: 'setup_instructions',
+    label: 'Setup Instructions',
+    value: '',
+    placeholder: '',
+    mask: false,
+    type: 'info',
+    required: false,
+    disabled: false,
+    options: [],
+    custom_field: false,
+    hidden: false,
+  };
+
+  it('renders the markdown description content', async () => {
+    const screen = await renderForm([
+      { ...baseInfoField, description: '**Bold text** here' },
+    ]);
+    const bold = screen.getByText('Bold text');
+    expect(bold).toBeInTheDocument();
+    expect(bold.tagName.toLowerCase()).toBe('strong');
+  });
+
+  it('does not render any input or textarea', async () => {
+    const screen = await renderForm([
+      { ...baseInfoField, description: 'Hello' },
+    ]);
+    expect(screen.queryByTestId('setup_instructions')).not.toBeInTheDocument();
+    const inputs = screen.container.querySelectorAll('input, textarea');
+    expect(inputs.length).toBe(0);
+  });
+
+  it('renders the label when present', async () => {
+    const screen = await renderForm([
+      { ...baseInfoField, description: 'Hi' },
+    ]);
+    expect(screen.getByText('Setup Instructions')).toBeInTheDocument();
+  });
+
+  it('renders without a label', async () => {
+    const screen = await renderForm([
+      { ...baseInfoField, label: '', description: 'No label here' },
+    ]);
+    expect(screen.getByText('No label here')).toBeInTheDocument();
+  });
+
+  it('renders complex Markdown (lists, links, bold)', async () => {
+    const description =
+      '1. **Step one**\n2. Visit [Apideck](https://apideck.com)\n';
+    const screen = await renderForm([
+      { ...baseInfoField, description },
+    ]);
+    expect(screen.getByText('Step one')).toBeInTheDocument();
+    const link = screen.getByText('Apideck') as HTMLAnchorElement;
+    expect(link.tagName.toLowerCase()).toBe('a');
+    expect(link.getAttribute('href')).toBe('https://apideck.com');
+  });
+});
+
+describe('ConnectionForm - {{field_id}} description interpolation', () => {
+  beforeEach(() => jest.spyOn(window, 'fetch'));
+  beforeEach(() => fetchMock(INVALID_SESSION_RESPONSE));
+  beforeEach(() => setupIntersectionObserverMock());
+
+  it('resolves a single token to the referenced field value', async () => {
+    const screen = await renderForm([
+      {
+        id: 'url',
+        label: 'URL',
+        value: 'https://example.com',
+        type: 'text',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: true,
+      },
+      {
+        id: 'info',
+        label: 'Info',
+        value: '',
+        type: 'info',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: false,
+        description: 'Visit {{url}}',
+      },
+    ]);
+    expect(screen.getByText(/Visit https:\/\/example\.com/)).toBeInTheDocument();
+  });
+
+  it('resolves multiple tokens', async () => {
+    const screen = await renderForm([
+      {
+        id: 'first',
+        label: 'First',
+        value: 'A',
+        type: 'text',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: true,
+      },
+      {
+        id: 'second',
+        label: 'Second',
+        value: 'B',
+        type: 'text',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: true,
+      },
+      {
+        id: 'info',
+        label: '',
+        value: '',
+        type: 'info',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: false,
+        description: '{{first}} and {{second}}',
+      },
+    ]);
+    expect(screen.getByText('A and B')).toBeInTheDocument();
+  });
+
+  it('replaces unresolved tokens with an empty string', async () => {
+    const screen = await renderForm([
+      {
+        id: 'info',
+        label: '',
+        value: '',
+        type: 'info',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: false,
+        description: 'before{{nonexistent}}after',
+      },
+    ]);
+    expect(screen.getByText('beforeafter')).toBeInTheDocument();
+  });
+
+  it('passes through descriptions without tokens unchanged', async () => {
+    const screen = await renderForm([
+      {
+        id: 'info',
+        label: '',
+        value: '',
+        type: 'info',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: false,
+        description: 'Plain description with no tokens',
+      },
+    ]);
+    expect(
+      screen.getByText('Plain description with no tokens')
+    ).toBeInTheDocument();
+  });
+
+  it('resolves tokens inside Markdown links', async () => {
+    const screen = await renderForm([
+      {
+        id: 'download_url',
+        label: 'Download URL',
+        value: 'https://files.example.com/foo.qwc',
+        type: 'text',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: true,
+      },
+      {
+        id: 'info',
+        label: '',
+        value: '',
+        type: 'info',
+        placeholder: '',
+        mask: false,
+        required: false,
+        disabled: false,
+        options: [],
+        custom_field: false,
+        hidden: false,
+        description: '[Download]({{download_url}})',
+      },
+    ]);
+    const link = screen.getByText('Download') as HTMLAnchorElement;
+    expect(link.tagName.toLowerCase()).toBe('a');
+    expect(link.getAttribute('href')).toBe(
+      'https://files.example.com/foo.qwc'
+    );
+  });
+});


### PR DESCRIPTION
# Summary                             

Adds three small, generic enhancements to ConnectionForm that any connector can use:

- type: "copy" — disabled TextInput with a copy-to-clipboard button (reuses @apideck/components TextInput.canBeCopied)
- type: "info" — Markdown-only block with no input element, styled as a soft gray card with numbered-list badges and bold action-style links — for setup instructions and rich help text
- {{field_id}} interpolation — tokens in any field's description resolve to the referenced field's value before Markdown rendering — enables dynamic links and credentials in help text

These ship the vault-core side of the QBD Web Connector setup UI. Spec-side schema/connector changes (allowing copy and info types in ConnectorSettings.json) are coming in a separate unify PR.

Ref apideck-io/unify#10707

# Test plan                                                                                                                                                                     

- Unit tests for all three enhancements (test/connection-form-field-types.test.tsx, 14 cases)
- Full suite green (yarn test --no-watch, 32/32)
- yarn build passes
- Visually verified against the QBD setup layout via the new ConnectionForm / Field types / QBDFullSetup story                                                                
- Reviewer: smoke-test the live Vault flow once the unify-side spec change deploys

# Migration notes

Purely additive. Older vault-core versions render unknown field types as nothing (graceful degradation), so connector specs can flip to the new types after this PR ships without coordinating a release.