### PR TITLE
fix: csrf protection not working in iframe and certain environments

### DIFF
--- a/example/iframe-test/README.md
+++ b/example/iframe-test/README.md
@@ -1,0 +1,66 @@
+# Iframe embedding test (GH-9546)
+
+Reproduces the production failure: Vault embedded in a storage-partitioned
+third-party iframe where `sessionStorage` is unavailable and the client-side
+OAuth nonce check breaks (connection stays `pending_confirmation`).
+
+## Approach (why same-origin)
+
+A sandboxed iframe *without* `allow-same-origin` gives the frame an opaque
+origin — which doesn't just block storage, it also sends `Origin: null` to
+Unify (CORS-rejected) and breaks React init, so **Vault never renders and you
+can't reach the Authorize button to observe the nonce failure at all**.
+
+So the frame is kept **same-origin** (Vault loads, API calls succeed, Authorize
+renders) and we sever **only `sessionStorage`** inside it — exactly what a
+partitioned/blocked third-party iframe does in practice.
+
+- **`iframe.html` / `iframe.tsx`** — host page. Renders the iframe and a
+  `sessionStorage:` selector that sets `?storage=` on the frame.
+- **`vault.html` / `vault.tsx`** — framed document. Replaces
+  `window.sessionStorage` with a shim per `?storage=`, then renders `<Vault>`
+  with a banner showing the resulting storage behaviour.
+
+### Modes
+
+| Mode | `?storage=` | sessionStorage behaviour | Reproduces |
+|---|---|---|---|
+| **Severed** (default) | `noop` | writes dropped, reads return `null` | nonce never matches → "Could not confirm" → stuck `pending_confirmation` |
+| **Denied** | `throw` | every op throws `SecurityError` | pre-fix `generateAndStoreNonce` crash on Authorize click |
+| **Normal** | `normal` | untouched | control — both builds work |
+
+## Run
+
+```bash
+# from repo root — build the library so example/dist is current
+yarn build
+
+cd example
+cp .env.example .env   # set VITE_VAULT_TOKEN to a live session JWT (CSRF allowlist)
+yarn install
+yarn start             # http://localhost:1234
+```
+
+Open **http://localhost:1234/iframe-test/iframe.html**.
+
+> Vault imports the built `../../dist` (same as the plain example), so re-run
+> `yarn build` at the repo root after changing `src/` to test a fix.
+
+## What to expect
+
+With **Severed** or **Denied** selected:
+
+- **Pre-fix build** (`generateAndStoreNonce` → `sessionStorage`): clicking an
+  OAuth Authorize button either crashes (`throw`) or completes the popup but
+  fails verification (`noop`) — the connection stays unconfirmed.
+- **Fixed build** (`generateNonce`, no storage): Authorize works regardless; the
+  red banner shows storage is broken yet the flow still confirms.
+
+Switch to **Normal** to confirm the harness itself is sound (both builds pass).
+
+## Caveat
+
+This reproduces the storage behaviour, not opaque-origin isolation. The genuine
+cross-site, partitioned-origin case additionally depends on Unify's CORS and on
+the OAuth popup `postMessage`-ing back to the opener — both Unify-side concerns
+separate from the client storage failure this harness targets.

--- a/example/iframe-test/iframe.html
+++ b/example/iframe-test/iframe.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Vault iframe embedding test (GH-9546)</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./iframe.tsx"></script>
+  </body>
+</html>

--- a/example/iframe-test/iframe.tsx
+++ b/example/iframe-test/iframe.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+// Host page that embeds the Vault (/vault.html) inside an iframe to reproduce
+// GH-9546: Vault running in a storage-partitioned third-party iframe where
+// sessionStorage is unavailable and the client nonce check fails.
+//
+// The iframe is kept SAME-ORIGIN on purpose. A sandbox without
+// `allow-same-origin` gives the frame an opaque origin, which not only blocks
+// storage but also sends `Origin: null` to Unify (CORS-rejected) and breaks
+// React init — so Vault never renders and you can't reach an Authorize button
+// to observe the nonce failure at all. Instead we keep the frame functional and
+// sever ONLY sessionStorage inside it (see vault.tsx ?storage=...), which is the
+// behaviour partitioning actually produces.
+
+const { useState } = React;
+
+type StorageMode = 'normal' | 'noop' | 'throw';
+
+const MODES: { value: StorageMode; label: string; hint: string }[] = [
+  { value: 'noop', label: 'Severed (drops writes, reads null)', hint: 'reproduces stuck "unconfirmed" — nonce never matches' },
+  { value: 'throw', label: 'Denied (throws SecurityError)', hint: 'reproduces the pre-fix generateAndStoreNonce crash' },
+  { value: 'normal', label: 'Normal (control)', hint: 'storage works — both builds succeed' },
+];
+
+const App = () => {
+  const [mode, setMode] = useState<StorageMode>('noop');
+  // Bump to force a fresh iframe (re-mount) when the mode changes.
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const current = MODES.find((m) => m.value === mode)!;
+  // Relative so it resolves under /iframe-test/ alongside this host page.
+  const src = `vault.html?storage=${mode}`;
+
+  return (
+    <div style={{ fontFamily: 'system-ui', maxWidth: 900, margin: '0 auto', padding: 24 }}>
+      <h1 style={{ marginBottom: 4 }}>Vault iframe embedding test</h1>
+      <p style={{ color: '#475569', marginTop: 0 }}>
+        Reproduces GH-9546: Vault embedded in a storage-partitioned iframe where{' '}
+        <code>sessionStorage</code> is unavailable and the client nonce check
+        fails. The frame stays same-origin so Vault loads and you can click
+        Authorize; only its <code>sessionStorage</code> is severed.
+      </p>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 16,
+          padding: 12,
+          border: '1px solid #e2e8f0',
+          borderRadius: 8,
+          marginBottom: 8,
+        }}
+      >
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span>sessionStorage:</span>
+          <select
+            value={mode}
+            onChange={(e) => {
+              setMode(e.target.value as StorageMode);
+              setReloadKey((k) => k + 1);
+            }}
+          >
+            {MODES.map((m) => (
+              <option key={m.value} value={m.value}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button onClick={() => setReloadKey((k) => k + 1)}>Reload iframe</button>
+        <code style={{ fontSize: 12, color: '#64748b' }}>{src}</code>
+      </div>
+
+      <div style={{ marginBottom: 8, fontSize: 13, color: '#475569' }}>
+        Current mode — <strong>{current.label}</strong>: {current.hint}.
+      </div>
+
+      <iframe
+        key={reloadKey}
+        title="vault"
+        src={src}
+        style={{
+          width: '100%',
+          height: 720,
+          border: '2px solid #cbd5e1',
+          borderRadius: 8,
+        }}
+      />
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/iframe-test/vault.html
+++ b/example/iframe-test/vault.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Vault (iframe content)</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./vault.tsx"></script>
+  </body>
+</html>

--- a/example/iframe-test/vault.tsx
+++ b/example/iframe-test/vault.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Vault } from '../../.';
+import '../../dist/styles.css';
+
+// This page is meant to be loaded *inside* an iframe (see iframe.html).
+//
+// To reproduce GH-9546 faithfully we keep the frame SAME-ORIGIN — so Vault
+// loads, its Unify API calls succeed (real Origin, not `null`), and the
+// Authorize button renders — and then sever ONLY sessionStorage, the way a
+// storage-partitioned / storage-blocked third-party iframe does in production.
+//
+//   ?storage=normal  → untouched (control)
+//   ?storage=noop    → severed: writes are dropped, reads return null
+//                      (reproduces "nonce never matches → stuck unconfirmed")
+//   ?storage=throw   → denied: every sessionStorage op throws SecurityError
+//                      (reproduces the pre-fix generateAndStoreNonce crash)
+//
+// Config comes from the same example/.env (see .env.example):
+//   VITE_VAULT_TOKEN, VITE_VAULT_UNIFIED_API, VITE_VAULT_SERVICE_ID,
+//   VITE_VAULT_UNIFY_BASE_URL (optional, e.g. staging)
+
+type StorageMode = 'normal' | 'noop' | 'throw';
+
+const storageMode = ((): StorageMode => {
+  const m = new URLSearchParams(window.location.search).get('storage');
+  return m === 'noop' || m === 'throw' ? m : 'normal';
+})();
+
+// Replace window.sessionStorage with a shim. We only touch sessionStorage (not
+// localStorage) to keep the blast radius tight — the shim's getter still
+// returns an object, so `typeof sessionStorage`/existence checks keep working;
+// only the actual read/write ops change behaviour.
+function installStorageShim(mode: StorageMode): boolean {
+  if (mode === 'normal') return true;
+
+  const denied = () => {
+    throw new DOMException(
+      "Failed to execute on 'Storage': access is denied for this document.",
+      'SecurityError'
+    );
+  };
+
+  const shim: Storage =
+    mode === 'throw'
+      ? ({
+          length: 0,
+          clear: denied,
+          getItem: denied,
+          key: denied,
+          removeItem: denied,
+          setItem: denied,
+        } as unknown as Storage)
+      : ({
+          // "severed" partition: writes silently dropped, reads always null.
+          length: 0,
+          clear: () => undefined,
+          getItem: () => null,
+          key: () => null,
+          removeItem: () => undefined,
+          setItem: () => undefined,
+        } as unknown as Storage);
+
+  try {
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get: () => shim,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const shimInstalled = installStorageShim(storageMode);
+
+const env = (import.meta as any).env ?? {};
+const token: string = env.VITE_VAULT_TOKEN ?? '';
+const unifiedApi: string = env.VITE_VAULT_UNIFIED_API ?? 'crm';
+const serviceId: string = env.VITE_VAULT_SERVICE_ID ?? 'hubspot';
+const unifyBaseUrl: string | undefined = env.VITE_VAULT_UNIFY_BASE_URL;
+
+// Probe what sessionStorage actually does in this frame, post-shim.
+function probeStorage(): { ok: boolean; detail: string } {
+  try {
+    const k = '__vault_iframe_probe__';
+    window.sessionStorage.setItem(k, '1');
+    const readBack = window.sessionStorage.getItem(k);
+    window.sessionStorage.removeItem(k);
+    if (readBack !== '1') {
+      return { ok: false, detail: 'writes are dropped (read-back is null)' };
+    }
+    return { ok: true, detail: 'sessionStorage reads/writes work' };
+  } catch (err) {
+    return {
+      ok: false,
+      detail: `sessionStorage threw: ${(err as Error)?.name}: ${
+        (err as Error)?.message
+      }`,
+    };
+  }
+}
+
+const StorageBanner = () => {
+  const probe = probeStorage();
+  return (
+    <div
+      style={{
+        fontFamily: 'system-ui',
+        fontSize: 13,
+        padding: '6px 12px',
+        color: '#fff',
+        background: probe.ok ? '#15803d' : '#b91c1c',
+      }}
+      data-testid="storage-banner"
+    >
+      <strong>{probe.ok ? 'storage: AVAILABLE' : 'storage: BLOCKED'}</strong>
+      {' — mode='}
+      <code>{storageMode}</code>
+      {shimInstalled ? '' : ' (shim install FAILED)'}
+      {' · '}
+      {probe.detail}
+    </div>
+  );
+};
+
+const App = () => {
+  if (!token) {
+    return (
+      <div style={{ padding: 24, fontFamily: 'system-ui' }}>
+        <h1>No JWT configured</h1>
+        <p>
+          Create <code>example/.env</code> with <code>VITE_VAULT_TOKEN=…</code>{' '}
+          (see <code>.env.example</code>) and restart <code>yarn start</code>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <StorageBanner />
+      <Vault
+        token={token}
+        open
+        unifiedApi={unifiedApi}
+        serviceId={serviceId}
+        unifyBaseUrl={unifyBaseUrl}
+      />
+    </>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -2,6 +2,16 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+// Multi-page: the plain direct render (index.html) plus the iframe-embedding
+// repro for GH-9546 — a host page (iframe.html) and the framed Vault document
+// (vault.html). In dev, Vite serves each by path (/iframe.html, /vault.html);
+// these inputs only matter for `vite build`.
+const pages = {
+  index: path.resolve(__dirname, 'index.html'),
+  iframe: path.resolve(__dirname, 'iframe-test/iframe.html'),
+  vault: path.resolve(__dirname, 'iframe-test/vault.html'),
+};
+
 // Force a single React copy across the example AND the in-tree vault-core source.
 // Without this, Vite finds nested React copies in the parent's node_modules and
 // the React tree fails with "Invalid hook call".
@@ -18,6 +28,11 @@ export default defineConfig({
     include: ['react', 'react-dom'],
   },
   css: { postcss: { plugins: [] } },
+  build: {
+    rollupOptions: {
+      input: pages,
+    },
+  },
   server: {
     port: 1234,
     open: false,

--- a/src/components/AuthorizeButton.tsx
+++ b/src/components/AuthorizeButton.tsx
@@ -6,12 +6,7 @@ import { useSWRConfig } from 'swr';
 import { REDIRECT_URL } from '../constants/urls';
 import { Connection } from '../types/Connection';
 import { OAuthPostMessage } from '../types/OAuthCsrf';
-import {
-  callConfirmEndpoint,
-  clearNonce,
-  generateAndStoreNonce,
-  verifyAndClearNonce,
-} from '../utils/oauthCsrf';
+import { callConfirmEndpoint, generateNonce } from '../utils/oauthCsrf';
 import { useConnections } from '../utils/useConnections';
 import { useSession } from '../utils/useSession';
 
@@ -106,7 +101,7 @@ const AuthorizeButton = ({
     } else {
       const serviceId = connection.service_id;
       const unifiedApi = connection.unified_api;
-      const nonce = generateAndStoreNonce(serviceId);
+      const nonce = generateNonce();
 
       const url = new URL(authorizeUrl);
       url.searchParams.append('nonce', nonce);
@@ -138,17 +133,6 @@ const AuthorizeButton = ({
           addToast({
             title: t('Authorization failed'),
             description: data.errorDescription || data.error,
-            type: 'error',
-            autoClose: true,
-          });
-          clearNonce(serviceId);
-          cleanup();
-          return;
-        }
-
-        if (!verifyAndClearNonce(serviceId, data.nonce)) {
-          addToast({
-            title: t('Could not confirm authorization'),
             type: 'error',
             autoClose: true,
           });

--- a/src/components/ButtonLayoutMenu.tsx
+++ b/src/components/ButtonLayoutMenu.tsx
@@ -7,7 +7,7 @@ import { Connection } from '../types/Connection';
 import { ConnectionViewType } from '../types/ConnectionViewType';
 import { SessionSettings } from '../types/Session';
 import { useConnectionActions } from '../utils/connectionActions';
-import { generateAndStoreNonce } from '../utils/oauthCsrf';
+import { generateNonce } from '../utils/oauthCsrf';
 import { getApiName } from '../utils/getApiName';
 import { useConnections } from '../utils/useConnections';
 import { useSession } from '../utils/useSession';
@@ -95,7 +95,7 @@ const ButtonLayoutMenu: React.FC<Props> = ({
           </svg>
         ),
         onClick: async () => {
-          const nonce = generateAndStoreNonce(connection.service_id);
+          const nonce = generateNonce();
           const url = new URL(
             `${authorize_url}&redirect_uri=${
               session?.redirect_uri ?? REDIRECT_URL
@@ -283,7 +283,7 @@ const ButtonLayoutMenu: React.FC<Props> = ({
           </svg>
         ),
         onClick: async () => {
-          const nonce = generateAndStoreNonce(connection.service_id);
+          const nonce = generateNonce();
           const url = new URL(
             `${authorize_url}&redirect_uri=${
               session?.redirect_uri ?? REDIRECT_URL

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -8,7 +8,7 @@ import { Connection } from '../types/Connection';
 import { ConnectionViewType } from '../types/ConnectionViewType';
 import { SessionSettings } from '../types/Session';
 import { useConnectionActions } from '../utils/connectionActions';
-import { generateAndStoreNonce } from '../utils/oauthCsrf';
+import { generateNonce } from '../utils/oauthCsrf';
 import { useConnections } from '../utils/useConnections';
 import { useSession } from '../utils/useSession';
 import ConfirmModal from './ConfirmModal';
@@ -237,7 +237,7 @@ const TopBar = ({
           </button>
         ),
         onClick: () => {
-          const nonce = generateAndStoreNonce(selectedConnection.service_id);
+          const nonce = generateNonce();
           const url = new URL(authorizeUrl);
           url.searchParams.append('nonce', nonce);
           handleRedirect(url.href, onConnectionChange);

--- a/src/types/OAuthCsrf.ts
+++ b/src/types/OAuthCsrf.ts
@@ -1,5 +1,7 @@
 export interface OAuthCompleteMessage {
   type: 'oauth_complete';
+  // Echoed back by unify for wire compatibility; received but unused — the
+  // client no longer verifies it (see oauthCsrf.ts `generateNonce`).
   nonce: string;
   confirmToken: string;
   serviceId: string;

--- a/src/utils/connectionActions.ts
+++ b/src/utils/connectionActions.ts
@@ -6,11 +6,7 @@ import { Connection } from '../types/Connection';
 import { ConnectionViewType } from '../types/ConnectionViewType';
 import { OAuthPostMessage } from '../types/OAuthCsrf';
 import { SessionSettings, VaultAction } from '../types/Session';
-import {
-  callConfirmEndpoint,
-  clearNonce,
-  verifyAndClearNonce,
-} from './oauthCsrf';
+import { callConfirmEndpoint } from './oauthCsrf';
 import { useConnections } from './useConnections';
 
 export const useConnectionActions = () => {
@@ -124,17 +120,6 @@ export const useConnectionActions = () => {
           addToast({
             title: t('Authorization failed'),
             description: data.errorDescription || data.error,
-            type: 'error',
-            autoClose: true,
-          });
-          clearNonce(serviceId);
-          cleanup();
-          return;
-        }
-
-        if (!verifyAndClearNonce(serviceId, data.nonce)) {
-          addToast({
-            title: t('Could not confirm authorization'),
             type: 'error',
             autoClose: true,
           });

--- a/src/utils/oauthCsrf.ts
+++ b/src/utils/oauthCsrf.ts
@@ -1,9 +1,5 @@
 import { ConfirmResponse } from '../types/OAuthCsrf';
 
-const STORAGE_PREFIX = 'apideck_oauth_nonce_';
-
-const storageKey = (serviceId: string) => `${STORAGE_PREFIX}${serviceId}`;
-
 const generateUuid = (): string => {
   const c: any =
     (typeof window !== 'undefined' ? window.crypto : undefined) ||
@@ -17,22 +13,14 @@ const generateUuid = (): string => {
     .slice(2)}-${Math.random().toString(36).slice(2)}`;
 };
 
-export function generateAndStoreNonce(serviceId: string): string {
-  const nonce = generateUuid();
-  sessionStorage.setItem(storageKey(serviceId), nonce);
-  return nonce;
-}
-
-export function verifyAndClearNonce(serviceId: string, nonce: string): boolean {
-  const key = storageKey(serviceId);
-  const stored = sessionStorage.getItem(key);
-  sessionStorage.removeItem(key);
-  if (stored === null) return false;
-  return stored === nonce;
-}
-
-export function clearNonce(serviceId: string): void {
-  sessionStorage.removeItem(storageKey(serviceId));
+// The nonce is an opaque value appended to the authorize URL purely as unify's
+// opt-in trigger for the confirm flow. unify echoes it back verbatim and never
+// verifies it server-side (CallbackConnectionUseCase.ts:394/475/494). The real
+// CSRF protection is the single-use, context-bound `confirm_token` enforced by
+// ConfirmConnectionUseCase.ts:62-69 against the authenticated session. So the
+// client only needs to generate a fresh value — no storage, no verification.
+export function generateNonce(): string {
+  return generateUuid();
 }
 
 export async function callConfirmEndpoint(params: {

--- a/test/authorize-button.test.tsx
+++ b/test/authorize-button.test.tsx
@@ -145,7 +145,6 @@ describe('Authorize button visibility', () => {
   });
 });
 
-const STORAGE_PREFIX = 'apideck_oauth_nonce_';
 const SERVICE_ID = 'shopify';
 const UNIFIED_API = 'ecommerce';
 const CONNECTIONS_URL = 'https://unify.apideck.com/vault/connections';
@@ -197,7 +196,6 @@ describe('Authorize button OAuth CSRF flow', () => {
   beforeEach(() => {
     jest.spyOn(window, 'fetch');
     setupIntersectionObserverMock();
-    sessionStorage.clear();
     fakeChild = { closed: false, close: jest.fn() };
     openSpy = jest
       .spyOn(window, 'open')
@@ -237,7 +235,7 @@ describe('Authorize button OAuth CSRF flow', () => {
     return { screen, mockData };
   };
 
-  it('appends &nonce= to the authorize URL and stores nonce in sessionStorage', async () => {
+  it('appends &nonce= to the authorize URL', async () => {
     await renderAndClickAuthorize();
 
     expect(openSpy).toHaveBeenCalledTimes(1);
@@ -247,12 +245,9 @@ describe('Authorize button OAuth CSRF flow', () => {
     const url = new URL(openedUrl);
     const nonceFromUrl = url.searchParams.get('nonce');
     expect(nonceFromUrl).toBeTruthy();
-
-    const stored = sessionStorage.getItem(`${STORAGE_PREFIX}${SERVICE_ID}`);
-    expect(stored).toBe(nonceFromUrl);
   });
 
-  it('on oauth_complete with valid nonce: POSTs to /confirm and clears the nonce', async () => {
+  it('on oauth_complete with valid nonce: POSTs to /confirm', async () => {
     const { mockData } = await renderAndClickAuthorize();
 
     const openedUrl = openSpy.mock.calls[0][0] as string;
@@ -283,8 +278,6 @@ describe('Authorize button OAuth CSRF flow', () => {
         confirm_token: 'token-xyz',
       });
     });
-
-    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${SERVICE_ID}`)).toBeNull();
   });
 
   it('on oauth_error: shows toast and does NOT call /confirm', async () => {
@@ -342,16 +335,16 @@ describe('Authorize button OAuth CSRF flow', () => {
     expect(confirmCall).toBeUndefined();
   });
 
-  it('on nonce mismatch: skips /confirm and surfaces an error toast', async () => {
-    const { screen, mockData } = await renderAndClickAuthorize();
+  it('on oauth_complete with an arbitrary nonce: still POSTs to /confirm', async () => {
+    const { mockData } = await renderAndClickAuthorize();
 
-    // Stored nonce is now whatever was generated. Send a different nonce.
+    // The client no longer verifies the nonce, so any value still confirms.
     await act(async () => {
       window.dispatchEvent(
         new MessageEvent('message', {
           data: {
             type: 'oauth_complete',
-            nonce: 'attacker-nonce',
+            nonce: 'arbitrary-value',
             confirmToken: 'token-xyz',
             serviceId: SERVICE_ID,
             success: true,
@@ -362,13 +355,15 @@ describe('Authorize button OAuth CSRF flow', () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.queryByText('Could not confirm authorization')
-      ).toBeInTheDocument();
+      const confirmCall = mockData.calls.find((c) =>
+        c.url.endsWith(`/${UNIFIED_API}/${SERVICE_ID}/confirm`)
+      );
+      expect(confirmCall).toBeDefined();
+      expect(confirmCall?.init?.method).toBe('POST');
+      expect(JSON.parse(confirmCall?.init?.body as string)).toEqual({
+        confirm_token: 'token-xyz',
+      });
     });
-
-    const confirmCall = mockData.calls.find((c) => c.url.endsWith('/confirm'));
-    expect(confirmCall).toBeUndefined();
   });
 
   it('falls back to mutate after 1000ms grace when child closes with no postMessage', async () => {

--- a/test/connection-actions.test.tsx
+++ b/test/connection-actions.test.tsx
@@ -9,10 +9,9 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 
 import { ConnectionsProvider } from '../src/utils/useConnections';
 import { useConnectionActions } from '../src/utils/connectionActions';
-import { generateAndStoreNonce } from '../src/utils/oauthCsrf';
+import { generateNonce } from '../src/utils/oauthCsrf';
 import '../src/utils/i18n';
 
-const STORAGE_PREFIX = 'apideck_oauth_nonce_';
 const SERVICE_ID = 'shopify';
 const UNIFIED_API = 'ecommerce';
 const UNIFY_BASE_URL = 'https://unify.apideck.com';
@@ -119,7 +118,6 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
 
   beforeEach(() => {
     jest.spyOn(window, 'fetch');
-    sessionStorage.clear();
     fakeChild = { closed: false, close: jest.fn() };
     openSpy = jest
       .spyOn(window, 'open')
@@ -135,8 +133,8 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
   const triggerAndOpen = async () => {
     const result = renderHost({
       url: AUTHORIZE_URL_BASE,
-      buildUrlAtClick: (serviceId, base) => {
-        const nonce = generateAndStoreNonce(serviceId);
+      buildUrlAtClick: (_serviceId, base) => {
+        const nonce = generateNonce();
         const u = new URL(base);
         u.searchParams.append('nonce', nonce);
         return u.href;
@@ -155,7 +153,7 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
     return result;
   };
 
-  it('appends &nonce= to the authorize URL and stores nonce in sessionStorage', async () => {
+  it('appends &nonce= to the authorize URL', async () => {
     await triggerAndOpen();
 
     expect(openSpy).toHaveBeenCalledTimes(1);
@@ -163,12 +161,9 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
     expect(openedUrl).toContain('nonce=');
     const nonceFromUrl = new URL(openedUrl).searchParams.get('nonce');
     expect(nonceFromUrl).toBeTruthy();
-    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${SERVICE_ID}`)).toBe(
-      nonceFromUrl
-    );
   });
 
-  it('on oauth_complete with valid nonce: POSTs to /confirm and clears the nonce', async () => {
+  it('on oauth_complete with valid nonce: POSTs to /confirm', async () => {
     const { calls } = await triggerAndOpen();
 
     const openedUrl = openSpy.mock.calls[0][0] as string;
@@ -199,8 +194,6 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
         confirm_token: 'token-xyz',
       });
     });
-
-    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${SERVICE_ID}`)).toBeNull();
   });
 
   it('on oauth_error: shows toast and does NOT call /confirm', async () => {
@@ -257,15 +250,16 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
     expect(confirmCall).toBeUndefined();
   });
 
-  it('on nonce mismatch: skips /confirm and surfaces an error toast', async () => {
-    const result = await triggerAndOpen();
+  it('on oauth_complete with an arbitrary nonce: still POSTs to /confirm', async () => {
+    const { calls } = await triggerAndOpen();
 
+    // The client no longer verifies the nonce, so any value still confirms.
     await act(async () => {
       window.dispatchEvent(
         new MessageEvent('message', {
           data: {
             type: 'oauth_complete',
-            nonce: 'attacker-nonce',
+            nonce: 'arbitrary-value',
             confirmToken: 'token-xyz',
             serviceId: SERVICE_ID,
             success: true,
@@ -276,21 +270,23 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
     });
 
     await waitFor(() => {
-      expect(
-        result.queryByText('Could not confirm authorization')
-      ).toBeInTheDocument();
+      const c = calls.find((c) =>
+        c.url.endsWith(`/${UNIFIED_API}/${SERVICE_ID}/confirm`)
+      );
+      expect(c).toBeDefined();
+      expect(c?.init?.method).toBe('POST');
+      expect(JSON.parse(c?.init?.body as string)).toEqual({
+        confirm_token: 'token-xyz',
+      });
     });
-
-    const confirmCall = result.calls.find((c) => c.url.endsWith('/confirm'));
-    expect(confirmCall).toBeUndefined();
   });
 
   it('falls back to mutate after 1000ms grace when child closes with no postMessage', async () => {
     jest.useFakeTimers();
     const { calls, getByText } = renderHost({
       url: AUTHORIZE_URL_BASE,
-      buildUrlAtClick: (serviceId, base) => {
-        const nonce = generateAndStoreNonce(serviceId);
+      buildUrlAtClick: (_serviceId, base) => {
+        const nonce = generateNonce();
         const u = new URL(base);
         u.searchParams.append('nonce', nonce);
         return u.href;

--- a/test/oauth-csrf.test.ts
+++ b/test/oauth-csrf.test.ts
@@ -1,78 +1,25 @@
 import 'whatwg-fetch';
 
-import {
-  callConfirmEndpoint,
-  clearNonce,
-  generateAndStoreNonce,
-  verifyAndClearNonce,
-} from '../src/utils/oauthCsrf';
-
-const STORAGE_PREFIX = 'apideck_oauth_nonce_';
+import { callConfirmEndpoint, generateNonce } from '../src/utils/oauthCsrf';
 
 describe('oauthCsrf utilities', () => {
-  beforeEach(() => {
-    sessionStorage.clear();
-  });
-
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  describe('generateAndStoreNonce', () => {
-    it('returns a non-empty string and stores it under the prefixed key', () => {
-      const nonce = generateAndStoreNonce('shopify');
+  describe('generateNonce', () => {
+    it('returns a non-empty string', () => {
+      const nonce = generateNonce();
 
       expect(typeof nonce).toBe('string');
       expect(nonce.length).toBeGreaterThan(0);
-      expect(sessionStorage.getItem(`${STORAGE_PREFIX}shopify`)).toBe(nonce);
     });
 
-    it('overwrites a previous nonce for the same serviceId', () => {
-      const first = generateAndStoreNonce('shopify');
-      const second = generateAndStoreNonce('shopify');
+    it('returns a different value on each call', () => {
+      const first = generateNonce();
+      const second = generateNonce();
 
       expect(second).not.toBe(first);
-      expect(sessionStorage.getItem(`${STORAGE_PREFIX}shopify`)).toBe(second);
-    });
-  });
-
-  describe('verifyAndClearNonce', () => {
-    it('returns true when the stored nonce matches and clears storage', () => {
-      const nonce = generateAndStoreNonce('shopify');
-
-      const result = verifyAndClearNonce('shopify', nonce);
-
-      expect(result).toBe(true);
-      expect(sessionStorage.getItem(`${STORAGE_PREFIX}shopify`)).toBeNull();
-    });
-
-    it('returns false when the stored nonce does not match and STILL clears storage', () => {
-      generateAndStoreNonce('shopify');
-
-      const result = verifyAndClearNonce('shopify', 'attacker-nonce');
-
-      expect(result).toBe(false);
-      expect(sessionStorage.getItem(`${STORAGE_PREFIX}shopify`)).toBeNull();
-    });
-
-    it('returns false when no nonce is stored for that serviceId', () => {
-      const result = verifyAndClearNonce('shopify', 'anything');
-
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('clearNonce', () => {
-    it('removes the stored nonce', () => {
-      generateAndStoreNonce('shopify');
-
-      clearNonce('shopify');
-
-      expect(sessionStorage.getItem(`${STORAGE_PREFIX}shopify`)).toBeNull();
-    });
-
-    it('is a no-op when nothing is stored', () => {
-      expect(() => clearNonce('shopify')).not.toThrow();
     });
   });
 

--- a/thoughts/shared/plans/2026-06-19-GH-9546-drop-client-nonce-storage.md
+++ b/thoughts/shared/plans/2026-06-19-GH-9546-drop-client-nonce-storage.md
@@ -1,0 +1,288 @@
+---
+github_issue_url: https://github.com/apideck-io/unify/issues/9546
+status: draft
+related_research: thoughts/shared/research/2026-05-05-GH-9546-csrf-fix-vault-core.md
+---
+
+# Drop Client-Side Nonce Storage & Verification Implementation Plan
+
+**Related Issue**: [GH-9546](https://github.com/apideck-io/unify/issues/9546) (OAuth CSRF — vault-core follow-up)
+
+---
+
+## Pattern Decisions
+
+- **Utility refactor:** Replace stateful `generateAndStoreNonce` with stateless `generateNonce` — keep the existing `generateUuid` helper and `callConfirmEndpoint` untouched (based on: `src/utils/oauthCsrf.ts`).
+- **postMessage handler pattern:** Existing per-call listener registered before `window.open`, torn down in `cleanup()` — unchanged. Only the nonce gate is removed (based on: `src/components/AuthorizeButton.tsx:127-187`, `src/utils/connectionActions.ts:113-173`).
+- **Test pattern:** `@testing-library/react` + `act()` + spied `window.open`/`window.fetch` + dispatched `MessageEvent`, mock setup from `test/mock.ts` (based on: `test/authorize-button.test.tsx`, `test/connection-actions.test.tsx`).
+- **Utilities identified:** `oauthCsrf` (`src/utils/oauthCsrf.ts`), `connectionActions` (`src/utils/connectionActions.ts`).
+- **Types to update:** None. `OAuthCompleteMessage.nonce` (`src/types/OAuthCsrf.ts:3`) stays — unify still puts `nonce` on the wire; the client simply stops reading it.
+
+---
+
+## Overview
+
+Remove the client-side OAuth nonce **storage** and **verification** from vault-core. Keep generating and appending a `nonce` query param to the authorize URL (it is unify's opt-in trigger for the confirm flow), but stop persisting it in `sessionStorage` and stop gating `/confirm` on a nonce match. The connection's security is enforced entirely server-side by the single-use, context-bound `confirm_token`; the client nonce check adds no security and is fragile in partitioned third-party iframes.
+
+## Current State Analysis
+
+The current flow stores a nonce in `sessionStorage` at authorize time and re-reads it to gate `/confirm`:
+
+- `generateAndStoreNonce` writes to `sessionStorage` (`src/utils/oauthCsrf.ts:20-24`).
+- `verifyAndClearNonce` reads + clears + compares (`:26-32`); `clearNonce` removes it (`:34-36`).
+- Both popup handlers block `/confirm` when `verifyAndClearNonce` returns false (`AuthorizeButton.tsx:149-157`, `connectionActions.ts:135-143`) and call `clearNonce` on `oauth_error` (`AuthorizeButton.tsx:144`, `connectionActions.ts:130`).
+
+**Two problems, one root cause — `sessionStorage` is unguarded:**
+
+- **3a (blocked storage throws):** In a storage-partitioned iframe, `sessionStorage.setItem` throws `SecurityError`; `generateAndStoreNonce` throws at `oauthCsrf.ts:22` before returning. Reproduced by 3 currently-failing tests in `test/oauth-csrf.test.ts:79-128` (`yarn test oauth-csrf` → 3 failed, 9 passed).
+- **3b (severed storage returns null):** `verifyAndClearNonce` returns `false` for a *legitimate* completion → "Could not confirm" toast → `/confirm` never fires → connection stuck `pending_confirmation`.
+
+This is exactly vault-core's deployment environment (embedded via iframe-vault), so a storage-dependent security check is both fragile and misplaced.
+
+### Key Discoveries (verified against unify source)
+
+- **The nonce is only a trigger server-side, never verified.** `unify/.../CallbackConnectionUseCase.ts:394` (`if (!nonce) return csrfEnabled: false`) and `:475` (`if (!nonce || !csrfEnabled) return redirectUri`). When present, the nonce is **echoed back verbatim** into the redirect hash (`:494-498`) — no comparison anywhere.
+- **The `confirm_token` is the real capability.** Fresh `uuidv4()` (`CallbackConnectionUseCase.ts:479`), stored single-use with 30-min TTL in a row keyed to `consumerId/applicationId/serviceId/unifiedApi` (`:482-491`).
+- **`/confirm` enforces a context match against the authenticated session.** `unify/.../ConfirmConnectionUseCase.ts:62-69` returns 401 unless the stored context matches the request — and `consumerId`/`applicationId` come from `authorizer(request)` (the JWT), not the body, which carries only `confirm_token` (`ConfirmConnectionController.ts` `isValid`). The nonce is never referenced in the confirm path.
+- **Conclusion:** A forged/replayed `oauth_complete` postMessage cannot confirm anything — the attacker has no `confirm_token` that passes the server-side context match. The client nonce verification is strictly redundant with stronger server controls.
+- vault-core reference surface (full list, build artifact `example/dist` excluded): `src/utils/oauthCsrf.ts`, `src/utils/connectionActions.ts`, `src/components/AuthorizeButton.tsx`, `src/components/TopBar.tsx`, `src/components/ButtonLayoutMenu.tsx`, `test/oauth-csrf.test.ts`, `test/authorize-button.test.tsx`, `test/connection-actions.test.tsx`.
+
+## Desired End State
+
+- `oauthCsrf.ts` exports `generateNonce` (stateless), `callConfirmEndpoint` — and no `verifyAndClearNonce`/`clearNonce`.
+- No code path in `src/` touches `sessionStorage`. `grep -rn "sessionStorage" src/` returns nothing.
+- The authorize URL still carries `&nonce=<uuid>` at all three call sites.
+- On `oauth_complete` for the matching `serviceId`, the handler calls `/confirm` directly — regardless of the message's `nonce` value.
+- `oauth_error` still toasts and skips `/confirm`; foreign-`serviceId` messages are still ignored; the 1000 ms grace-period fallback and double-confirm guard are unchanged.
+- `yarn test --no-watch` green; `tsdx build` and `tsdx lint` pass.
+
+**Verify:** `yarn test --no-watch` (full suite green, including no orphaned references), `grep -rn "verifyAndClearNonce\|clearNonce\|generateAndStoreNonce\|sessionStorage" src/ test/` returns nothing.
+
+## What We're NOT Doing
+
+- **Not** removing the `nonce` query param from the authorize URL — it remains the server's opt-in trigger; dropping it disables CSRF protection entirely (plain redirect, no `confirm_token`).
+- **Not** changing `callConfirmEndpoint`, the postMessage listener lifecycle, the 1000 ms grace fallback, or the `child.closed` polling.
+- **Not** removing the `nonce` field from `OAuthCompleteMessage` — it stays on the wire from unify; we just ignore it client-side.
+- **Not** adding an `event.origin` check — white-label / custom redirect domains mean there is no fixed origin to pin.
+- **Not** touching unify or vault. (Out-of-scope note recorded in Migration Notes.)
+- **Not** changing `pending_confirmation` UI or `client_credentials`/`password` grant paths.
+
+## Implementation Approach
+
+The utility export and its consumers are a single atomic unit: removing `verifyAndClearNonce`/`clearNonce` from `oauthCsrf.ts` requires removing every importer in the same change, or TypeScript compilation breaks across the whole test suite. So the TDD cycle is structured as: **(RED)** rewrite all three test files to the target behavior, then **(GREEN)** land the util refactor and all consumers together, then verify, then refactor cleanup. No type-change phase is needed (the wire types are unchanged).
+
+---
+
+## Phase 1: Rewrite Tests to Target Behavior (TDD - RED)
+
+### Overview
+
+Rewrite the three test files so they assert the post-removal behavior. These fail until Phase 2 lands (the util `generateNonce` doesn't exist yet, and the handlers still gate on `verifyAndClearNonce`).
+
+### Session Startup Protocol
+1. Verify working directory: `pwd`
+2. Read progress JSON: `thoughts/shared/progress/2026-06-19-GH-9546-drop-client-nonce-storage-status.json`
+3. Confirm current phase matches JSON `current_phase`
+
+### Changes Required:
+
+#### 1. `test/oauth-csrf.test.ts`
+**Change**: Replace the storage-based describe blocks with `generateNonce` tests; keep `callConfirmEndpoint`.
+
+**Key Implementation Notes**:
+- Update import to `{ callConfirmEndpoint, generateNonce }`.
+- Delete the `generateAndStoreNonce`, `verifyAndClearNonce`, `clearNonce`, and `sessionStorage unavailable (in-memory fallback)` describe blocks (`:21-129`) — including the 3 currently-failing tests, whose premise (in-memory fallback) no longer exists.
+- Delete the `STORAGE_PREFIX` constant and `beforeEach(sessionStorage.clear())`.
+- New `describe('generateNonce')`:
+  - returns a non-empty string.
+  - returns a different value on each call (uniqueness).
+  - does **not** touch `sessionStorage`: spy `Storage.prototype.setItem` and assert it is **not** called; assert `generateNonce` does **not** throw even when `setItem` is mocked to throw.
+- Leave the `callConfirmEndpoint` describe block (`:131-186`) unchanged.
+
+#### 2. `test/authorize-button.test.tsx`
+**Change**: Drop storage assertions; assert `/confirm` proceeds regardless of nonce value.
+
+**Key Implementation Notes**:
+- Remove the `STORAGE_PREFIX` constant (`:148`).
+- "appends &nonce= ... and stores nonce in sessionStorage" (`:240-253`) → keep the URL `nonce=` assertions, **delete** the `sessionStorage.getItem(...)` assertion.
+- "on oauth_complete with valid nonce: POSTs to /confirm and clears the nonce" (`:255-288`) → rename to drop "and clears the nonce"; **delete** the trailing `sessionStorage.getItem(...).toBeNull()` assertion.
+- Replace "on nonce mismatch: skips /confirm and surfaces an error toast" (`:345-372`) with **"on oauth_complete with an arbitrary nonce: still POSTs to /confirm"** — dispatch `oauth_complete` with `nonce: 'arbitrary-value'` and assert a `/confirm` POST **is** made (the new behavior).
+- Keep unchanged: oauth_error skips confirm (`:290-313`), foreign serviceId ignored (`:315-343`), grace fallback (`:374-421`), no double-confirm (`:423-483`).
+
+#### 3. `test/connection-actions.test.tsx`
+**Change**: Mirror the authorize-button updates for `handleRedirect`.
+
+**Key Implementation Notes**:
+- Update import `generateAndStoreNonce` → `generateNonce` (`:12`); the `buildUrlAtClick` helpers (`:139`, `:293`) call `generateNonce(serviceId? )` — `generateNonce` takes no serviceId arg, so call `generateNonce()`.
+- Remove `STORAGE_PREFIX` (`:15`).
+- "appends &nonce= ... and stores nonce in sessionStorage" (`:158-169`) → delete the `sessionStorage.getItem(...)` assertion.
+- "on oauth_complete with valid nonce ... clears the nonce" (`:171-204`) → delete the trailing `sessionStorage.getItem(...).toBeNull()` assertion.
+- Replace "on nonce mismatch: skips /confirm" (`:260-286`) with "arbitrary nonce: still POSTs to /confirm".
+- Keep oauth_error, foreign serviceId, grace fallback unchanged.
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch` runs and the **rewritten** specs fail for the expected reasons (missing `generateNonce` export; handler still gating → "arbitrary nonce still confirms" fails). Other suites unaffected (src still compiles — `oauthCsrf.ts` unchanged this phase).
+
+#### Manual Verification:
+- Confirm the 3 ex-failing storage-fallback tests are gone, not merely skipped.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 1: rewrite OAuth CSRF tests for stateless nonce (TDD - RED)"` (+ `Co-Authored-By: Claude <noreply@anthropic.com>`)
+2. Update progress JSON: phase 1 → "complete", `current_phase` → 2.
+3. `git status` clean.
+
+---
+
+## Phase 2: Remove Nonce Storage Across Util + Consumers (TDD - GREEN)
+
+### Overview
+
+Land the atomic refactor: stateless `generateNonce`, delete `verifyAndClearNonce`/`clearNonce`, and update all four `src/` consumers so the handlers confirm without a nonce gate. All Phase-1 tests go green.
+
+### Session Startup Protocol
+1. Verify working directory: `pwd`
+2. Check previous phase committed: `git log -1 --oneline`
+3. Read progress JSON; confirm `current_phase` is 2.
+
+### Changes Required:
+
+#### 1. `src/utils/oauthCsrf.ts`
+**Change**: Stateless nonce; remove verify/clear.
+**Key Implementation Notes**:
+- Replace `generateAndStoreNonce` (`:20-24`) with `export function generateNonce(): string { return generateUuid(); }`.
+- Delete `verifyAndClearNonce` (`:26-32`) and `clearNonce` (`:34-36`).
+- Keep `generateUuid` (`:7-18`) and `callConfirmEndpoint` (`:38-68`) unchanged. `STORAGE_PREFIX`/`storageKey` (`:3-5`) become dead — delete them.
+- Add a brief comment documenting the contract: *the nonce is opaque, echoed by unify, and never verified server-side (see unify `CallbackConnectionUseCase.ts:394/475/494`, `ConfirmConnectionUseCase.ts:62-69`); security is the single-use, context-bound `confirm_token`.*
+
+#### 2. `src/components/AuthorizeButton.tsx`
+**Key Implementation Notes**:
+- Import (`:9-14`): drop `clearNonce`, `verifyAndClearNonce`; rename `generateAndStoreNonce` → `generateNonce`.
+- `:109`: `const nonce = generateNonce();`
+- oauth_error branch (`:144`): remove `clearNonce(serviceId);`.
+- Remove the verify gate (`:149-157`) entirely — proceed straight from the `serviceId` check to the `callConfirmEndpoint` try-block. `data.nonce` is no longer read.
+
+#### 3. `src/utils/connectionActions.ts`
+**Key Implementation Notes**:
+- Import (`:9-13`): drop `clearNonce`, `verifyAndClearNonce` (keep `callConfirmEndpoint`).
+- oauth_error branch (`:130`): remove `clearNonce(serviceId);`.
+- Remove the verify gate (`:135-143`).
+
+#### 4. `src/components/TopBar.tsx`
+**Key Implementation Notes**:
+- Import (`:11`) and call site (`:240`): `generateAndStoreNonce(selectedConnection.service_id)` → `generateNonce()`.
+
+#### 5. `src/components/ButtonLayoutMenu.tsx`
+**Key Implementation Notes**:
+- Import (`:10`) and both call sites (`:98`, `:286`): `generateAndStoreNonce(connection.service_id)` → `generateNonce()`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch` — full suite green.
+- `tsdx build` succeeds (no unused-import / missing-export errors).
+- `tsdx lint` passes.
+- `grep -rn "sessionStorage" src/` returns nothing.
+
+#### Manual Verification:
+- In the example app / Storybook, an OAuth authorize popup still appends `&nonce=` and the connection confirms on `oauth_complete`.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 2: remove client-side nonce storage and verification (TDD - GREEN) Ref #9546"` (+ `Co-Authored-By`).
+2. Progress JSON: phase 2 → "complete", `current_phase` → 3.
+3. `git status` clean.
+
+---
+
+## Phase 3: Verify Full Suite (TDD - GREEN verification)
+
+### Overview
+Confirm the whole suite, build, and lint are green and no orphaned references remain.
+
+### Session Startup Protocol
+1. `pwd`; `git log -1 --oneline`; read progress JSON; confirm `current_phase` is 3.
+
+### Changes Required:
+- No code changes. Run verification commands and fix any fallout discovered (e.g., an unmigrated reference).
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch` — all suites pass.
+- `tsdx build` and `tsdx lint` pass.
+- `grep -rn "verifyAndClearNonce\|clearNonce\|generateAndStoreNonce\|apideck_oauth_nonce_\|sessionStorage" src/ test/` returns nothing.
+
+#### Manual Verification:
+- Re-run `yarn test oauth-csrf` — 0 failing (the original 3 reds are gone).
+
+### Session Completion
+1. If fixes were needed: commit `git add -A && git commit -m "Phase 3: verification fixes"`; else no commit.
+2. Progress JSON: phase 3 → "complete", `current_phase` → 4.
+3. `git status` clean.
+
+---
+
+## Phase 4: Cleanup (TDD - REFACTOR)
+
+### Overview
+Tidy comments and remove any now-dead test scaffolding while the suite stays green.
+
+### Session Startup Protocol
+1. `pwd`; `git log -1 --oneline`; read progress JSON; confirm `current_phase` is 4.
+
+### Changes Required:
+- Remove leftover unused constants/imports in the three test files (e.g., `STORAGE_PREFIX`, any unused `sessionStorage` setup) if not already removed.
+- Ensure the `oauthCsrf.ts` contract comment is accurate and concise.
+- Confirm the `OAuthCompleteMessage.nonce` field retains a short comment noting it is received-but-unused (wire compatibility).
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch`, `tsdx build`, `tsdx lint` all green.
+
+#### Manual Verification:
+- Diff review: no behavioral change vs. Phase 2; comments accurate.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 4: cleanup after nonce-storage removal (TDD - REFACTOR)"` (+ `Co-Authored-By`).
+2. Progress JSON: phase 4 → "complete".
+3. `git status` clean.
+
+---
+
+## Testing Strategy
+
+**Follow TDD (red-green-refactor).** This is a removal/refactor, so the RED phase rewrites existing tests to the target behavior rather than authoring brand-new components.
+
+### Unit Tests (`test/oauth-csrf.test.ts`):
+- `generateNonce`: non-empty, unique per call, never touches `sessionStorage`, never throws even if `Storage.prototype.setItem` is mocked to throw.
+- `callConfirmEndpoint`: unchanged (URL/headers/body/response, non-2xx throws).
+
+### Component / Integration Tests (`authorize-button.test.tsx`, `connection-actions.test.tsx`):
+- Authorize URL still carries `&nonce=`.
+- `oauth_complete` (matching `serviceId`) → `/confirm` POST with `{ confirm_token }`, **regardless of nonce value** (new behavior; replaces the nonce-mismatch test).
+- `oauth_error` → toast, no `/confirm`.
+- Foreign `serviceId` → ignored.
+- 1000 ms grace fallback and no-double-confirm guard preserved.
+- No `sessionStorage` assertions anywhere.
+
+### Manual Testing Steps:
+1. Example app: authorize an OAuth2 connector; verify popup URL has `&nonce=` and the connection confirms on completion.
+2. Simulate a partitioned iframe (block storage in devtools) and confirm authorize no longer throws.
+
+## Performance Considerations
+
+Negligible — removes two `sessionStorage` round-trips per OAuth flow.
+
+## Migration Notes
+
+- **Contract dependency:** This hard-codes "nonce is opaque, echoed, never verified server-side." That matches unify today (`CallbackConnectionUseCase`/`ConfirmConnectionUseCase`). If unify ever adds server-side nonce verification, a non-storing client would break — record this on the unify side as a do-not-do, and keep the contract comment in `oauthCsrf.ts`.
+- **Backwards compatible:** Non-allowlisted accounts already receive a plain redirect; sending an unverified nonce is harmless. No data migration.
+- **Cross-repo:** vault (`src/utils/oauthCsrf.ts`) still stores+verifies its own nonce on the redirect-return path; that is a separate codebase and out of scope here.
+
+## References
+
+- Related research: `thoughts/shared/research/2026-05-05-GH-9546-csrf-fix-vault-core.md`
+- Server-side controls (verified): `unify/src/modules/connection/application/useCases/confirmConnection/ConfirmConnectionUseCase.ts:62-69`; `.../ConfirmConnectionController.ts` (`isValid`); `.../callbackConnection/CallbackConnectionUseCase.ts:394,475,479-498`
+- Client handlers: `src/components/AuthorizeButton.tsx:127-187`, `src/utils/connectionActions.ts:113-173`

--- a/thoughts/shared/progress/2026-06-19-GH-9546-drop-client-nonce-storage-status.json
+++ b/thoughts/shared/progress/2026-06-19-GH-9546-drop-client-nonce-storage-status.json
@@ -1,0 +1,11 @@
+{
+  "plan": "2026-06-19-GH-9546-drop-client-nonce-storage.md",
+  "current_phase": 1,
+  "total_phases": 4,
+  "phases": [
+    {"id": 1, "name": "Rewrite Tests to Target Behavior (TDD - RED)", "status": "pending"},
+    {"id": 2, "name": "Remove Nonce Storage Across Util + Consumers (TDD - GREEN)", "status": "pending"},
+    {"id": 3, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "pending"},
+    {"id": 4, "name": "Cleanup (TDD - REFACTOR)", "status": "pending"}
+  ]
+}


### PR DESCRIPTION
Because of session storage, there are cases where it will not work for certain customers.

We could just check if sessionStorage is available, if not dont use csrf protection, but technically storing and checking the nonce is not required. We just use it as a feature flag in a sense.