### PR TITLE
OAuth confirm grant handoff: fix connections stuck at pending_confirmation under COOP

### DIFF
--- a/example/grant-handoff/README.md
+++ b/example/grant-handoff/README.md
@@ -1,0 +1,158 @@
+# grant-handoff end-to-end harness — the OCTA fix, proven against REAL unify
+
+Drives the **real** `<Vault>` through the **new** OAuth grant-handoff code path
+(`src/utils/oauthGrantHandoff.ts` + `src/components/AuthorizeButton.tsx`)
+against **REAL local unify** (`https://localhost:3050`) with a **REAL** OAuth
+round-trip (real QuickBooks consent, real `confirm_token`). The harness serves
+only its **own** vault-side `oauth/launch` + `oauth/callback` stand-ins, so it
+can withhold/inject the COOP header and force the severed-opener condition
+deterministically. Nothing about unify is stubbed.
+
+## What it proves
+
+The OCTA failure (reproduced in `../opener-severed-confirm/`): when the OAuth
+popup's navigation chain crosses a `COOP: same-origin` page, the browser swaps
+browsing-context groups and the popup's `window.opener` becomes **null**. The
+legacy flow delivered the `confirm_token` back through that opener, so the
+connection stranded at `pending_confirmation`.
+
+This harness shows that with the grant-handoff fix, in **severed** mode:
+
+- the callback's `window.opener` **is null** (old channel dead), **yet**
+- the connection still reaches state **`callable`**, because the callback
+  **self-confirms in-tab** with a grant it read from the tab's vault-origin
+  `sessionStorage`, POSTing `{ confirm_token, grant }` straight to REAL unify —
+  it never needs the opener.
+
+In **intact** mode the connection also reaches `callable` (the self-confirm
+never used the opener either). The contrast with `../opener-severed-confirm/`,
+where severed mode strands the connection, is the whole point.
+
+## How one severed run flows
+
+```
+outer (localhost, top host, sets gh_opener cookie)
+ └─ middle ([::1], iframe)
+     └─ widget (127.0.0.1, iframe) — REAL <Vault>, new grant-handoff path
+         │ click Authorize
+         │ POST {unify}/vault/connections/accounting/quickbooks/grant  → REAL grant
+         │ window.open ─────────────► /oauth/launch  (localhost = vault, NO COOP)
+         │ ◄── oauth_launch_ready (opener LIVE here)      │
+         │ ──── oauth_launch_start { grant, authorizeUrl }►│ stash grant in
+         │      (explicit targetOrigin = launch origin)    │ sessionStorage,
+         │                                                 │ navigate tab ▼
+         │                                    REAL unify authorize → REAL QuickBooks
+         │                                             │  consent, unify mints
+         │                                             │  confirm_token, 302 ▼
+         │                                    /oauth/callback (localhost, COOP:
+         │                                             │  same-origin → context
+         │                                             │  group swaps, opener dies)
+         │                                             │  read grant (single-use),
+         │                                             │  opener === null,
+         │                                             │  POST { confirm_token, grant }
+         │                                             ▼    to REAL unify /confirm
+         └── widget status panel polls REAL unify connection detail ◄── state → callable
+```
+
+The grant travels only via postMessage → sessionStorage → the confirm POST
+body. It **never** appears in any URL (that rule is security-load-bearing).
+
+## Prerequisites
+
+- **unify** running locally on `https://localhost:3050` with the grant-handoff
+  PR (`POST .../grant`; `.../confirm` accepting `{ confirm_token, grant }`).
+  Visit **https://localhost:3050 once in the browser** to accept its self-signed
+  cert, or the in-browser `fetch`es fail.
+- The connector under test configured in unify for app **2222**:
+  `unified_api=accounting`, `service_id=quickbooks` (already in `example/.env`).
+- **QuickBooks sandbox** reachable for the real consent screen.
+- vault on `http://localhost:3003` is **optional** — this harness serves its own
+  launch/callback stand-ins and does not use vault's pages.
+- A **real unify-issued session token** in `example/.env` (`VITE_VAULT_TOKEN`),
+  minted below. Its top-level `redirect_uri` claim must be
+  `http://localhost:1234/oauth/callback`.
+
+## Run
+
+```bash
+# 1. Mint a real session token into example/.env (leaves other vars intact):
+cd example
+UNIFY_ADMIN_API_KEY=sk_... ./grant-handoff/mint-session.sh
+#   (or: ./grant-handoff/mint-session.sh --key sk_...)
+#   Prints the token exp. Tokens are ~1h TTL — re-run when it expires.
+
+# 2. From the repo root, build vault-core so example/ imports the compiled dist:
+cd ..
+yarn build
+
+# 3. Start the example dev server:
+cd example
+yarn install   # first time only
+yarn start     # http://localhost:1234
+```
+
+Open on **localhost** (the origins assume it) and allow popups:
+
+- **Control (intact):**
+  http://localhost:1234/grant-handoff/outer.html?opener=intact
+- **OCTA repro (severed — the real test):**
+  http://localhost:1234/grant-handoff/outer.html?opener=severed
+
+Click **Authorize** in the widget, complete the real QuickBooks consent, and let
+the popup walk the chain back to `/oauth/callback`.
+
+## Expected result
+
+| Mode | Widget status panel (live unify state) | Callback popup verdict |
+|---|---|---|
+| `intact` | flips to **callable ✅ (PASS)** | self-confirm fired; `window.opener` LIVE (unused) |
+| `severed` | flips to **callable ✅ (PASS)** | **GO ✅ — `window.opener: null` but self-confirm fired** |
+
+In **severed** mode the callback shows `window.opener` **null** — the OLD flow
+would strand the connection right here — yet the connection still reaches
+`callable` via the in-tab self-confirm. That is the fix.
+
+Contrast: in `../opener-severed-confirm/`, severed mode leaves the connection
+stuck (the dropped `confirm_token` is never confirmed).
+
+## Files
+
+| File | Origin | Stands in for |
+|---|---|---|
+| `outer.tsx` / `.html` | `localhost` | customer top-level host + mode toggle (sets `gh_opener` cookie) |
+| `middle.tsx` / `.html` | `[::1]` | middle cross-origin iframe |
+| `widget.tsx` / `.html` | `127.0.0.1` | embedded vault-core widget — REAL `<Vault>` |
+| `launch.tsx` / `.html` | `localhost` | REAL vault `oauth/launch` (NO COOP) |
+| `callback.tsx` / `.html` | `localhost` | REAL vault `oauth/callback` self-confirm (COOP lever in severed) |
+| `origins.ts` | — | origins, mode, service ids, unify base, storage key |
+| `mint-session.sh` | — | mints a real unify session token into `example/.env` |
+
+The `/oauth/*` rewrites and the callback COOP lever live in `../vite.config.ts`
+(`grantHandoffPlugin`). There is **no** unify stub and **no** CORS shim — unify
+serves its own endpoints and CORS.
+
+### Safari note
+
+Safari cannot load literal-IPv6 origins (`http://[::1]:…`). On Safari-like
+browsers the middle-iframe hop falls back to `127.0.0.1` (see `isSafariLike` in
+`origins.ts`). The widget is still cross-origin to the localhost outer/vault, and
+the opener severance comes from COOP on the callback, so the repro still holds.
+
+### confirm_token delivery
+
+unify delivers the `confirm_token` in the redirect back to
+`http://localhost:1234/oauth/callback`. Per the sequence diagrams
+(`../../thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md`)
+it arrives in the URL **fragment** (`…/oauth/callback#…confirm_token…`). The
+callback stand-in is tolerant — it scans both the query string and the hash for
+`confirm_token` (and a few variants) and logs the raw URL to the console so you
+can see exactly how unify delivered it.
+
+## Related
+
+- Today's failure repro: `../opener-severed-confirm/`
+- The sessionStorage assumption this relies on: `../storage-roundtrip/`
+- Problem & requirements:
+  `../../thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md`
+- Sequence diagrams:
+  `../../thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md`

--- a/example/grant-handoff/callback.html
+++ b/example/grant-handoff/callback.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>grant-handoff — vault oauth/callback (in-tab self-confirm)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/grant-handoff/callback.tsx"></script>
+  </body>
+</html>

--- a/example/grant-handoff/callback.tsx
+++ b/example/grant-handoff/callback.tsx
@@ -1,0 +1,223 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {
+  SERVICE_ID,
+  UNIFIED_API,
+  UNIFY_BASE_URL,
+  grantStorageKey,
+  readMode,
+  readRun,
+} from './origins';
+
+// REAL vault `oauth/callback` self-confirm stand-in — back on the vault origin
+// (localhost), SAME TAB, after the REAL unify → QuickBooks round-trip. In
+// ?opener=severed the Vite middleware serves THIS page with COOP: same-origin
+// (a browsing-context-group swap), since in production we don't control the
+// real callback's effective policy either → window.opener goes null here.
+//
+// It answers the whole point of the harness:
+//   - window.opener — the OLD channel. Expected NULL in severed mode (the
+//     confirm_token would have been dropped right here in the legacy flow).
+//   - the grant — read back from the tab's vault-origin sessionStorage and
+//     single-use-deleted, then POSTed UNAUTHENTICATED with the confirm_token to
+//     REAL unify's confirm endpoint (the in-tab self-confirm). No opener needed.
+
+const { useEffect, useState } = React;
+
+const mode = readMode();
+const run = readRun();
+const serviceId = SERVICE_ID;
+const unifiedApi = UNIFIED_API;
+
+// unify delivers the confirm_token in the redirect back to redirect_uri. The
+// sequence diagrams (2026-07-16-oauth-confirm-handoff-sequence-diagrams.md) show
+// it in the URL FRAGMENT (`…/oauth/callback#nonce&confirm_token&service_id`),
+// but the exact carrier (query vs hash) and casing depend on the real unify
+// build — so be tolerant: scan BOTH the query string and the hash, accept a few
+// common names, and log what actually arrived for in-browser inspection.
+function readConfirmToken(): { token: string | null; from: string } {
+  const names = ['confirm_token', 'confirmToken', 'confirm-token', 'token'];
+  const search = new URLSearchParams(window.location.search);
+  const hash = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+  for (const n of names) {
+    const q = search.get(n);
+    if (q) return { token: q, from: `query:${n}` };
+  }
+  for (const n of names) {
+    const h = hash.get(n);
+    if (h) return { token: h, from: `hash:${n}` };
+  }
+  return { token: null, from: 'none' };
+}
+
+const { token: confirmToken, from: confirmTokenFrom } = readConfirmToken();
+
+// Log the raw URL parts so a human can see exactly how unify delivered the
+// token (param name, query vs fragment) if our tolerant scan misses it.
+// eslint-disable-next-line no-console
+console.log('[grant-handoff callback] location', {
+  search: window.location.search,
+  hash: window.location.hash,
+  confirmToken,
+  confirmTokenFrom,
+});
+
+const openerAlive = !!window.opener;
+
+let storageReadable = true;
+let grant: string | null = null;
+try {
+  grant = sessionStorage.getItem(grantStorageKey(serviceId));
+  if (grant !== null) {
+    // Single-use, like the real confirm secret.
+    sessionStorage.removeItem(grantStorageKey(serviceId));
+  }
+} catch {
+  storageReadable = false;
+}
+
+const grantSurvived = grant !== null;
+
+type Phase = 'confirming' | 'confirmed' | 'confirm-failed' | 'no-grant';
+
+const App = () => {
+  const [phase, setPhase] = useState<Phase>(
+    grantSurvived && confirmToken ? 'confirming' : 'no-grant'
+  );
+  const [errorText, setErrorText] = useState<string>('');
+
+  useEffect(() => {
+    if (!grantSurvived || !confirmToken) {
+      setPhase('no-grant');
+      return;
+    }
+    // In-tab self-confirm against REAL unify: UNAUTHENTICATED body (no Bearer),
+    // cross-origin from this localhost page to unify (https://localhost:3050),
+    // so a CORS preflight fires — unify handles its own CORS.
+    fetch(
+      `${UNIFY_BASE_URL}/vault/connections/${unifiedApi}/${serviceId}/confirm`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirm_token: confirmToken, grant }),
+      }
+    )
+      .then(async (res) => {
+        if (res.ok) {
+          setPhase('confirmed');
+          window.setTimeout(() => window.close(), 2000);
+        } else {
+          const body = await res.text().catch(() => '');
+          setErrorText(`HTTP ${res.status} ${body.slice(0, 300)}`);
+          setPhase('confirm-failed');
+        }
+      })
+      .catch((err) => {
+        setErrorText(String(err));
+        setPhase('confirm-failed');
+      });
+  }, []);
+
+  const verdict =
+    phase === 'confirmed'
+      ? mode === 'severed' && !openerAlive
+        ? {
+            color: '#15803d',
+            title: 'GO ✅ — opener null but self-confirm fired',
+            detail:
+              'window.opener is null (the legacy flow would have dropped the confirm_token right here), yet the grant survived in the tab’s vault-origin sessionStorage and the in-tab POST /confirm to REAL unify succeeded. The connection will go callable — this is the fix.',
+          }
+        : {
+            color: '#15803d',
+            title: 'Self-confirm fired ✅',
+            detail: `POST /confirm to REAL unify succeeded in-tab. window.opener is ${
+              openerAlive ? 'also alive (intact mode)' : 'null'
+            } — the flow never used it. The connection will go callable.`,
+          }
+      : phase === 'confirming'
+      ? {
+          color: '#b45309',
+          title: 'Confirming in-tab…',
+          detail:
+            'POSTing { confirm_token, grant } to REAL unify’s confirm endpoint (unauthenticated).',
+        }
+      : phase === 'confirm-failed'
+      ? {
+          color: '#b91c1c',
+          title: 'Confirm POST failed ❌',
+          detail: `The grant survived but the in-tab POST /confirm did not succeed. Left open for inspection. ${errorText}`,
+        }
+      : {
+          color: '#b91c1c',
+          title: 'NO-GO ❌ — grant/confirm_token missing',
+          detail: storageReadable
+            ? `sessionStorage was readable but the grant (${
+                grantSurvived ? 'present' : 'MISSING'
+              }) or confirm_token (${
+                confirmToken ? 'present' : 'MISSING'
+              }) was gone. Check the console log for how unify delivered the token.`
+            : 'sessionStorage was not readable at the callback (blocked storage?).',
+        };
+
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: 24 }}>
+      <h2 style={{ marginTop: 0 }}>
+        vault oauth/callback (in-tab self-confirm)
+      </h2>
+      <div
+        style={{
+          padding: '10px 14px',
+          borderRadius: 6,
+          color: '#fff',
+          background: verdict.color,
+        }}
+      >
+        <strong>{verdict.title}</strong>
+        <div style={{ marginTop: 6, fontSize: 13, opacity: 0.95 }}>
+          {verdict.detail}
+        </div>
+      </div>
+      <table style={{ marginTop: 16, fontSize: 13, color: '#334155' }}>
+        <tbody>
+          <tr>
+            <td style={{ paddingRight: 12 }}>mode</td>
+            <td>
+              <code>{mode}</code>
+            </td>
+          </tr>
+          <tr>
+            <td style={{ paddingRight: 12 }}>window.opener (old channel)</td>
+            <td>
+              <strong>{openerAlive ? 'LIVE' : 'null'}</strong>
+            </td>
+          </tr>
+          <tr>
+            <td style={{ paddingRight: 12 }}>grant via sessionStorage</td>
+            <td>
+              <strong>{grantSurvived ? 'survived' : 'MISSING'}</strong>
+            </td>
+          </tr>
+          <tr>
+            <td style={{ paddingRight: 12 }}>confirm_token</td>
+            <td>
+              <code>{confirmToken ?? '(none)'}</code> ({confirmTokenFrom})
+            </td>
+          </tr>
+          <tr>
+            <td style={{ paddingRight: 12 }}>run</td>
+            <td>
+              <code>{run}</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p style={{ fontSize: 13, color: '#475569' }}>
+        {phase === 'confirmed'
+          ? 'This window closes itself shortly, like the real callback. The widget’s status panel flips to callable.'
+          : 'Left open for inspection. See the browser console for the raw callback URL unify redirected to.'}
+      </p>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/grant-handoff/launch.html
+++ b/example/grant-handoff/launch.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>grant-handoff — vault oauth/launch</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/grant-handoff/launch.tsx"></script>
+  </body>
+</html>

--- a/example/grant-handoff/launch.tsx
+++ b/example/grant-handoff/launch.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { grantStorageKey } from './origins';
+
+// REAL vault `oauth/launch` stand-in — the popup's FIRST document, on the vault
+// origin (localhost), served WITHOUT COOP (the /oauth/launch rewrite in
+// ../vite.config.ts never attaches COOP here). Because we control this page's
+// headers, window.opener is intact by construction, even in severed mode:
+// severance happens LATER, when the tab lands on the COOP-served callback.
+//
+// It speaks the PRODUCTION grant-handoff protocol (src/types/OAuthGrantHandoff.ts):
+//   - popup -> widget: { type: 'oauth_launch_ready' }         (repeated until answered)
+//   - widget -> popup: { type: 'oauth_launch_start', grant, authorizeUrl }
+//
+// Sequence:
+//   1. refuse without an opener (anti-phishing guardrail)
+//   2. write-read self-test sessionStorage
+//   3. post oauth_launch_ready to the opener every ~250ms until answered
+//   4. on oauth_launch_start: stash the grant in this tab's vault-origin
+//      sessionStorage (NEVER a URL), then navigate the tab to authorizeUrl —
+//      the REAL unify authorize URL the widget posted (redirect_uri back to our
+//      /oauth/callback + nonce). No local provider hop exists.
+
+const { useEffect, useState } = React;
+
+const params = new URLSearchParams(window.location.search);
+const serviceId = params.get('service_id') ?? 'unknown';
+
+type Status =
+  | 'starting'
+  | 'no-opener'
+  | 'no-storage'
+  | 'waiting-grant'
+  | 'grant-timeout'
+  | 'navigating';
+
+const App = () => {
+  const [status, setStatus] = useState<Status>('starting');
+
+  useEffect(() => {
+    // Guardrail 1: no opener ⇒ no flow (a handed-out launcher link must go
+    // nowhere). This is also what a COOP: same-origin embedding page would trip.
+    if (!window.opener) {
+      setStatus('no-opener');
+      return;
+    }
+
+    // Guardrail 2: storage must demonstrably work before we rely on it.
+    try {
+      const probe = grantStorageKey('__selftest__');
+      sessionStorage.setItem(probe, '1');
+      if (sessionStorage.getItem(probe) !== '1') throw new Error('mismatch');
+      sessionStorage.removeItem(probe);
+    } catch {
+      setStatus('no-storage');
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setStatus('grant-timeout'), 8000);
+
+    // Repeat the ready ping until the widget answers with oauth_launch_start.
+    // The ping carries no secret, so '*' as targetOrigin is fine; the grant
+    // comes back with an explicit targetOrigin from the widget side.
+    let answered = false;
+    const ping = () => {
+      if (answered) return;
+      (window.opener as Window).postMessage(
+        { type: 'oauth_launch_ready' },
+        '*'
+      );
+    };
+    ping();
+    const pinger = window.setInterval(ping, 250);
+
+    const onMessage = (event: MessageEvent) => {
+      const data = event.data as
+        | { type?: string; grant?: unknown; authorizeUrl?: unknown }
+        | undefined;
+      if (data?.type !== 'oauth_launch_start') return;
+      if (typeof data.grant !== 'string') return;
+      if (typeof data.authorizeUrl !== 'string') return;
+
+      answered = true;
+      window.clearInterval(pinger);
+      window.clearTimeout(timeout);
+      window.removeEventListener('message', onMessage);
+
+      // The grant now lives ONLY in this tab's vault-origin sessionStorage — no
+      // URL ever carries it. The callback (also localhost) reads it back.
+      sessionStorage.setItem(grantStorageKey(serviceId), data.grant);
+      setStatus('navigating');
+
+      // Navigate the tab to the REAL unify authorize URL. Whatever COOP unify /
+      // QuickBooks apply along the way is irrelevant now — the grant is already
+      // safe in sessionStorage; only the final callback needs the opener-null
+      // condition, which our dev server injects there.
+      window.location.replace(data.authorizeUrl);
+    };
+    window.addEventListener('message', onMessage);
+
+    setStatus('waiting-grant');
+
+    return () => {
+      window.clearInterval(pinger);
+      window.clearTimeout(timeout);
+      window.removeEventListener('message', onMessage);
+    };
+  }, []);
+
+  const text: Record<Status, { msg: string; color: string }> = {
+    starting: { msg: 'starting…', color: '#475569' },
+    'no-opener': {
+      msg: 'REFUSED — window.opener is null at launch, so no grant can be delivered and the flow must not start (phished launcher link, or COOP on the embedding page itself).',
+      color: '#b91c1c',
+    },
+    'no-storage': {
+      msg: 'REFUSED — sessionStorage is unavailable. Production would fall back to the legacy opener path instead of proceeding.',
+      color: '#b91c1c',
+    },
+    'waiting-grant': {
+      msg: 'opener is LIVE — posting oauth_launch_ready, waiting for oauth_launch_start with the grant…',
+      color: '#b45309',
+    },
+    'grant-timeout': {
+      msg: 'no grant arrived — the widget did not complete the handshake.',
+      color: '#b91c1c',
+    },
+    navigating: {
+      msg: 'grant stashed in vault-origin sessionStorage — navigating the tab to REAL unify authorize…',
+      color: '#15803d',
+    },
+  };
+
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: 24 }}>
+      <h2 style={{ marginTop: 0 }}>vault oauth/launch (real stand-in)</h2>
+      <div
+        style={{
+          padding: '10px 14px',
+          borderRadius: 6,
+          color: '#fff',
+          background: text[status].color,
+        }}
+      >
+        <strong>{text[status].msg}</strong>
+      </div>
+      <p style={{ fontSize: 13, color: '#475569' }}>
+        service_id <code>{serviceId}</code> · origin{' '}
+        <code>{window.location.origin}</code> · served WITHOUT COOP, so the
+        opener link is intact here by construction.
+      </p>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/grant-handoff/middle.html
+++ b/example/grant-handoff/middle.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>grant-handoff — middle iframe</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./middle.tsx"></script>
+  </body>
+</html>

--- a/example/grant-handoff/middle.tsx
+++ b/example/grant-handoff/middle.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { ORIGINS, readMode } from './origins';
+
+// Middle iframe, served from [::1] — cross-origin to both the top-level host
+// (localhost) and the widget it embeds (127.0.0.1). Its only job is to add a
+// second cross-origin boundary above the widget, matching OCTA's nesting.
+
+const mode = readMode();
+const widgetSrc = `${ORIGINS.widget}/grant-handoff/widget.html?opener=${mode}`;
+
+const App = () => (
+  <div style={{ margin: 0, fontFamily: 'system-ui' }}>
+    <div
+      style={{
+        padding: '4px 12px',
+        font: '11px/1.4 system-ui',
+        color: '#334155',
+        background: '#e2e8f0',
+      }}
+    >
+      middle iframe · <code>{ORIGINS.middle}</code> (cross-origin to host and
+      widget)
+    </div>
+    <iframe
+      title="widget"
+      src={widgetSrc}
+      style={{ width: '100%', height: 'calc(100vh - 84px)', border: 'none' }}
+    />
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/grant-handoff/mint-session.sh
+++ b/example/grant-handoff/mint-session.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Mint a REAL unify session token for the grant-handoff harness and write it into
+# example/.env as VITE_VAULT_TOKEN (leaving other vars intact).
+#
+# The token carries a TOP-LEVEL `redirect_uri` claim of
+# http://localhost:1234/oauth/callback, so <Vault>'s deriveLaunchUrl opens our
+# local /oauth/launch stand-in. (unify accepts top-level redirect_uri; a
+# settings.redirect_uri 400s — do not use that.)
+#
+# Usage:
+#   UNIFY_ADMIN_API_KEY=sk_... ./grant-handoff/mint-session.sh
+#   ./grant-handoff/mint-session.sh --key sk_...
+#
+# Options:
+#   --key <key>        unify admin API key (else read from $UNIFY_ADMIN_API_KEY)
+#   --unify <url>      unify base URL (default https://localhost:3050)
+#   --redirect <url>   redirect_uri (default http://localhost:1234/oauth/callback)
+#   --app <id>         X-APIDECK-APP-ID (default 2222)
+#   --consumer <id>    X-APIDECK-CONSUMER-ID (default test-consumer)
+#
+# Notes:
+#   - unify runs with a self-signed cert; curl uses -k. Visit https://localhost:3050
+#     once in the browser first to accept the cert for the in-browser fetches.
+#   - Tokens are ~1h TTL — re-run this when the widget stops loading connections.
+#   - NEVER hardcode a key in this file or commit one; .env is gitignored.
+
+set -euo pipefail
+
+KEY="${UNIFY_ADMIN_API_KEY:-}"
+UNIFY="https://localhost:3050"
+REDIRECT="http://localhost:1234/oauth/callback"
+APP_ID="2222"
+CONSUMER_ID="test-consumer"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --key) KEY="$2"; shift 2 ;;
+    --unify) UNIFY="$2"; shift 2 ;;
+    --redirect) REDIRECT="$2"; shift 2 ;;
+    --app) APP_ID="$2"; shift 2 ;;
+    --consumer) CONSUMER_ID="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$KEY" ]]; then
+  echo "error: no unify admin API key. Set \$UNIFY_ADMIN_API_KEY or pass --key <key>." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$(cd "$SCRIPT_DIR/.." && pwd)/.env"
+
+echo "Minting session against $UNIFY (redirect_uri=$REDIRECT, app=$APP_ID, consumer=$CONSUMER_ID)…" >&2
+
+RESPONSE="$(curl -sk -X POST "$UNIFY/vault/sessions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $KEY" \
+  -H "X-APIDECK-CONSUMER-ID: $CONSUMER_ID" \
+  -H "X-APIDECK-APP-ID: $APP_ID" \
+  -d "{\"redirect_uri\":\"$REDIRECT\",\"consumer_metadata\":{\"account_name\":\"Sample\"}}")"
+
+# Extract data.session_token without requiring jq.
+extract_token() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -r '.data.session_token // empty'
+  else
+    printf '%s' "$1" | sed -n 's/.*"session_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+  fi
+}
+
+TOKEN="$(extract_token "$RESPONSE")"
+
+if [[ -z "$TOKEN" ]]; then
+  echo "error: no session_token in unify response:" >&2
+  echo "$RESPONSE" >&2
+  exit 1
+fi
+
+# Decode the JWT payload (2nd segment, base64url) and print the exp for sanity.
+decode_exp() {
+  local payload="${TOKEN#*.}"; payload="${payload%%.*}"
+  # base64url -> base64, pad to a multiple of 4.
+  payload="${payload//-/+}"; payload="${payload//_//}"
+  while [[ $(( ${#payload} % 4 )) -ne 0 ]]; do payload="${payload}="; done
+  local json
+  json="$(printf '%s' "$payload" | base64 -d 2>/dev/null || true)"
+  local exp
+  if command -v jq >/dev/null 2>&1; then
+    exp="$(printf '%s' "$json" | jq -r '.exp // empty')"
+  else
+    exp="$(printf '%s' "$json" | sed -n 's/.*"exp"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p')"
+  fi
+  if [[ -n "$exp" ]]; then
+    local human
+    human="$(date -r "$exp" 2>/dev/null || date -d "@$exp" 2>/dev/null || echo "$exp")"
+    echo "token exp: $exp ($human)" >&2
+  fi
+}
+decode_exp
+
+# Write/update VITE_VAULT_TOKEN in example/.env, leaving other vars intact.
+touch "$ENV_FILE"
+if grep -q '^VITE_VAULT_TOKEN=' "$ENV_FILE"; then
+  tmp="$(mktemp)"
+  # Use a non-/ delimiter — JWTs contain no '|'.
+  sed "s|^VITE_VAULT_TOKEN=.*|VITE_VAULT_TOKEN=$TOKEN|" "$ENV_FILE" > "$tmp"
+  mv "$tmp" "$ENV_FILE"
+else
+  printf 'VITE_VAULT_TOKEN=%s\n' "$TOKEN" >> "$ENV_FILE"
+fi
+
+echo "Wrote VITE_VAULT_TOKEN to $ENV_FILE. Restart 'yarn start' to pick it up." >&2

--- a/example/grant-handoff/origins.ts
+++ b/example/grant-handoff/origins.ts
@@ -1,0 +1,103 @@
+// Grant-handoff end-to-end harness — drives the REAL <Vault> through the NEW
+// grant-handoff code path (src/utils/oauthGrantHandoff.ts +
+// src/components/AuthorizeButton.tsx) against REAL local unify (https://localhost:3050)
+// with a REAL OAuth round-trip. The ONLY things this harness serves itself are
+// the vault-side oauth/launch + oauth/callback stand-ins, so it can withhold /
+// inject COOP headers and force the severed-opener condition deterministically.
+// Everything unify does (grant, authorize, provider redirect, confirm_token
+// minting, /confirm) is REAL.
+//
+// Same three-loopback-origin trick as ../opener-severed-confirm/ and
+// ../storage-roundtrip/: ONE Vite dev server (`server.host: true`), several
+// distinct origins that all hit it. Different hostnames = different origins, so
+// nesting outer -> middle -> widget gives genuine cross-origin iframe
+// boundaries.
+//
+//   outer / host (localhost)   top-level customer host — carries intact/severed
+//                              toggle. ALSO the VAULT origin (launch + callback
+//                              live here, equal to the session redirect_uri origin).
+//   middle       ([::1])       middle cross-origin iframe
+//   widget       (127.0.0.1)   inner cross-origin iframe — runs the REAL <Vault>
+//   vault        (localhost)   oauth/launch + oauth/callback (served here via
+//                              the /oauth/* rewrite in ../vite.config.ts)
+//
+// The real OAuth provider is unify + QuickBooks; there is NO local provider hop.
+//
+// Open the harness on localhost so `outer`/`vault` are the localhost origin
+// these URLs assume — and the session redirect_uri origin:
+//   http://localhost:1234/grant-handoff/outer.html?opener=severed
+
+const PORT =
+  typeof window !== 'undefined' && window.location.port
+    ? window.location.port
+    : '1234';
+
+// Safari cannot load literal-IPv6 URLs (http://[::1]:…) — a long-standing
+// WebKit/Safari networking limitation Chrome, Firefox and DuckDuckGo don't
+// share. On Safari-like browsers the middle-iframe hop falls back to 127.0.0.1
+// (cosmetically it then shares the widget's origin, but the widget is still
+// cross-origin to the localhost outer/vault, which is all this harness needs —
+// the severance is produced by COOP on the callback, not by the iframe nesting).
+export const isSafariLike =
+  typeof navigator !== 'undefined' &&
+  /safari/i.test(navigator.userAgent) &&
+  !/chrome|chromium|crios|firefox|fxios|edg/i.test(navigator.userAgent);
+
+export const ORIGINS = {
+  outer: `http://localhost:${PORT}`,
+  middle: isSafariLike ? `http://127.0.0.1:${PORT}` : `http://[::1]:${PORT}`,
+  widget: `http://127.0.0.1:${PORT}`,
+  vault: `http://localhost:${PORT}`,
+};
+
+// The connector under test (see example/.env). These are used by the launch +
+// callback stand-ins for the sessionStorage key and the real /confirm URL; the
+// widget reads them from VITE_* env so the REAL <Vault> and this harness agree.
+const env = (import.meta as any).env ?? {};
+export const UNIFIED_API: string = env.VITE_VAULT_UNIFIED_API ?? 'accounting';
+export const SERVICE_ID: string = env.VITE_VAULT_SERVICE_ID ?? 'quickbooks';
+
+// REAL local unify. The widget's <Vault> talks to it for grant + authorize, and
+// the callback stand-in POSTs the self-confirm here (unauthenticated).
+export const UNIFY_BASE_URL: string =
+  env.VITE_VAULT_UNIFY_BASE_URL || 'https://localhost:3050';
+
+export type OpenerMode = 'intact' | 'severed';
+
+export function readMode(): OpenerMode {
+  const m =
+    typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search).get('opener')
+      : null;
+  return m === 'severed' ? 'severed' : 'intact';
+}
+
+// Correlation id for one run — NOT a secret, purely for display. The grant is
+// the secret and never appears in any URL (it travels only via postMessage,
+// sessionStorage and the confirm POST body).
+export function readRun(): string {
+  return typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('run') ?? 'no-run'
+    : 'no-run';
+}
+
+export function randomId(): string {
+  const c = typeof crypto !== 'undefined' ? (crypto as any) : undefined;
+  if (c?.randomUUID) return c.randomUUID();
+  return `${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+// Stable, per-service sessionStorage key on the vault origin (localhost). The
+// launch page stashes the grant here; the callback page reads it back and
+// single-use-deletes it. Both pages are localhost, so they share the tab's
+// vault-origin sessionStorage bucket (which survives COOP context-group swaps).
+export const grantStorageKey = (serviceId: string) =>
+  `oauth_grant:${serviceId}`;
+
+// Cookie the outer host sets so the dev server can apply the callback COOP lever
+// in severed mode. Real unify redirects back to our /oauth/callback WITHOUT our
+// ?opener param, so the query string is not a reliable signal on the callback
+// request; a localhost cookie (outer and callback are both localhost) is sent on
+// the top-level navigation and survives the real-unify round-trip. See
+// grantHandoffPlugin in ../vite.config.ts.
+export const OPENER_COOKIE = 'gh_opener';

--- a/example/grant-handoff/outer.html
+++ b/example/grant-handoff/outer.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>grant-handoff — top-level host</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./outer.tsx"></script>
+  </body>
+</html>

--- a/example/grant-handoff/outer.tsx
+++ b/example/grant-handoff/outer.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { ORIGINS, OPENER_COOKIE, readMode } from './origins';
+
+// Top-level host page. It embeds the middle frame from a DIFFERENT origin
+// ([::1]), which in turn embeds the widget from a third origin (127.0.0.1) —
+// reproducing OCTA's nested cross-origin iframe chain with real browser
+// isolation. The ?opener=severed | intact mode is threaded down to every frame
+// via the iframe src query; in severed mode the Vite dev middleware attaches
+// `Cross-Origin-Opener-Policy: same-origin` to the OAuth popup's callback page
+// so the popup's window.opener is genuinely null at callback time — exactly the
+// production condition.
+//
+// The point this harness makes (vs ../opener-severed-confirm/, where severed
+// mode strands the connection): the NEW grant-handoff flow reaches state
+// `callable` in BOTH modes, because the vault callback self-confirms in-tab
+// with the grant it read from sessionStorage — it no longer needs the opener.
+
+const mode = readMode();
+const severed = mode === 'severed';
+
+// Real unify redirects the browser back to /oauth/callback WITHOUT our ?opener
+// param, so the dev server can't read the mode off the callback request's query.
+// Persist it in a localhost cookie instead: outer and the callback are both
+// localhost, and a SameSite=Lax cookie is sent on the top-level navigation unify
+// triggers, surviving the real-unify round-trip. The dev server reads it to
+// decide whether to apply COOP to the callback (see grantHandoffPlugin).
+if (typeof document !== 'undefined') {
+  document.cookie = `${OPENER_COOKIE}=${mode}; path=/; SameSite=Lax`;
+}
+
+const middleSrc = `${ORIGINS.middle}/grant-handoff/middle.html?opener=${mode}`;
+
+const link = (m: string, label: string) => (
+  <a
+    href={`?opener=${m}`}
+    style={{
+      color: '#fff',
+      fontWeight: mode === m ? 700 : 400,
+      textDecoration: mode === m ? 'underline' : 'none',
+    }}
+  >
+    {label}
+  </a>
+);
+
+const App = () => (
+  <div style={{ fontFamily: 'system-ui', margin: 0 }}>
+    <div
+      style={{
+        padding: '10px 16px',
+        color: '#fff',
+        background: severed ? '#b91c1c' : '#15803d',
+        font: '13px/1.5 system-ui',
+      }}
+    >
+      <strong>
+        NEW grant-handoff flow · window.opener:{' '}
+        {severed ? 'SEVERED (COOP: same-origin)' : 'intact'}
+      </strong>{' '}
+      — top <code>{ORIGINS.outer}</code> ▸ iframe <code>{ORIGINS.middle}</code>{' '}
+      ▸ iframe <code>{ORIGINS.widget}</code> · {link('intact', 'intact')} |{' '}
+      {link('severed', 'severed (OCTA repro)')}
+      <div style={{ marginTop: 4, opacity: 0.9 }}>
+        {severed
+          ? 'The OAuth popup completes the REAL unify + QuickBooks round-trip, then lands on our /oauth/callback served with COOP: same-origin, cross-origin to the widget → window.opener is null. The OLD channel that would have carried the confirm_token back is dead — yet the callback self-confirms in-tab with the grant, so the connection still reaches callable.'
+          : 'Happy path: the opener survives the whole chain, but the callback still self-confirms in-tab with the grant (never uses the opener) — the connection reaches callable.'}
+      </div>
+    </div>
+    <iframe
+      title="middle"
+      src={middleSrc}
+      style={{ width: '100%', height: 'calc(100vh - 62px)', border: 'none' }}
+    />
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/grant-handoff/widget.html
+++ b/example/grant-handoff/widget.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>grant-handoff — widget (real Vault, new grant-handoff flow)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./widget.tsx"></script>
+  </body>
+</html>

--- a/example/grant-handoff/widget.tsx
+++ b/example/grant-handoff/widget.tsx
@@ -1,0 +1,178 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Vault } from '../../.';
+import '../../dist/styles.css';
+import {
+  ORIGINS,
+  SERVICE_ID,
+  UNIFIED_API,
+  UNIFY_BASE_URL,
+  readMode,
+} from './origins';
+
+// The innermost frame, served from 127.0.0.1 — nested two cross-origin iframes
+// deep (see outer.tsx / middle.tsx). It renders the REAL @apideck/react-vault
+// <Vault> on the NEW grant-handoff code path (openGrantHandoffPopup +
+// watchPopupCloseAndPoll in src/utils/oauthGrantHandoff.ts, wired from
+// src/components/AuthorizeButton.tsx). Nothing about window.open is patched;
+// the opener severance is produced by real browser isolation (COOP on the
+// popup's callback page), exactly as in OCTA.
+//
+// This is a REAL end-to-end run against REAL local unify (https://localhost:3050):
+//   - <Vault> mints a REAL grant   → POST {unify}/vault/connections/accounting/quickbooks/grant
+//   - opens {vault}/oauth/launch   → our COOP-free stand-in (localhost)
+//   - hands the grant over via the production postMessage handshake
+//   - launch navigates the tab to the REAL unify authorize_url → REAL QuickBooks
+//   - unify mints a confirm_token, redirects to {vault}/oauth/callback
+//   - our callback self-confirms in-tab against REAL unify
+// Nothing here is stubbed.
+
+const { useEffect, useState } = React;
+
+const mode = readMode();
+const severed = mode === 'severed';
+
+// REAL unify-issued session JWT (mint with grant-handoff/mint-session.sh, which
+// writes VITE_VAULT_TOKEN into example/.env). Its top-level `redirect_uri` claim
+// is load-bearing: deriveLaunchUrl takes its origin (http://localhost:1234) as
+// launchOrigin and opens http://localhost:1234/oauth/launch?service_id=…, so the
+// launch page is served from the same origin the handshake pins.
+const env = (import.meta as any).env ?? {};
+const token: string = env.VITE_VAULT_TOKEN ?? '';
+const unifiedApi: string = UNIFIED_API;
+const serviceId: string = SERVICE_ID;
+const unifyBaseUrl: string = UNIFY_BASE_URL;
+
+// App + consumer for the live-state poll headers (see example/.env / mint recipe).
+const APP_ID = '2222';
+const CONSUMER_ID = 'test-consumer';
+
+type ConnState = 'loading' | 'error' | string;
+
+// Optional live view of the REAL unify connection state (added → callable),
+// polled directly from the widget with the session JWT headers. Purely
+// diagnostic — the actual pass/fail is unify flipping the connection to
+// `callable` after the in-tab self-confirm.
+const StatusPanel = () => {
+  const [state, setState] = useState<ConnState>('loading');
+
+  useEffect(() => {
+    if (!token) return;
+    let stop = false;
+    const poll = async () => {
+      try {
+        const res = await fetch(
+          `${unifyBaseUrl}/vault/connections/${unifiedApi}/${serviceId}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'X-APIDECK-APP-ID': APP_ID,
+              'X-APIDECK-CONSUMER-ID': CONSUMER_ID,
+            },
+          }
+        );
+        const body = await res.json();
+        if (!stop) setState(body?.data?.state ?? 'unknown');
+      } catch {
+        if (!stop) setState('error');
+      }
+    };
+    poll();
+    const id = window.setInterval(poll, 1500);
+    return () => {
+      stop = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const callable = state === 'callable';
+  const bg = callable ? '#15803d' : state === 'loading' ? '#475569' : '#b45309';
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 2147483647,
+        background: bg,
+        color: '#fff',
+        font: '13px/1.5 system-ui',
+        padding: '10px 16px',
+        boxShadow: '0 -2px 12px rgba(0,0,0,0.25)',
+      }}
+    >
+      <strong>
+        Live connection state (real unify):{' '}
+        {callable ? 'callable ✅ (PASS)' : `${state} (waiting…)`}
+      </strong>
+      <div style={{ marginTop: 4, opacity: 0.95 }}>
+        {callable
+          ? severed
+            ? 'PASS — window.opener was severed by COOP on the callback (old channel dead) yet the connection reached callable: the vault callback self-confirmed in-tab with the grant. This is exactly what the grant-handoff fix buys.'
+            : 'PASS — connection reached callable via the in-tab self-confirm (the opener was never needed).'
+          : `Polling ${unifyBaseUrl}/vault/connections/${unifiedApi}/${serviceId} every 1.5s. Click Authorize, complete the REAL QuickBooks consent, and this flips to callable.`}
+      </div>
+    </div>
+  );
+};
+
+const App = () => (
+  <div style={{ fontFamily: 'system-ui', padding: '16px 16px 96px' }}>
+    <div
+      style={{
+        padding: '8px 12px',
+        color: '#fff',
+        borderRadius: 6,
+        marginBottom: 16,
+        background: severed ? '#b91c1c' : '#15803d',
+        fontSize: 13,
+      }}
+    >
+      <strong>widget</strong> · <code>{ORIGINS.widget}</code> · opener{' '}
+      <strong>{severed ? 'SEVERED' : 'intact'}</strong> · REAL unify E2E — NEW
+      grant-handoff flow · unify <code>{unifyBaseUrl}</code>
+    </div>
+
+    {token ? (
+      <Vault
+        token={token}
+        open
+        unifiedApi={unifiedApi}
+        serviceId={serviceId}
+        unifyBaseUrl={unifyBaseUrl}
+        showButtonLayout
+      />
+    ) : (
+      <div style={{ fontSize: 14, color: '#334155' }}>
+        <p>
+          No <code>VITE_VAULT_TOKEN</code> set. Mint a REAL unify session token
+          (it must carry a top-level <code>redirect_uri</code> claim of{' '}
+          <code>http://localhost:1234/oauth/callback</code>) and write it into{' '}
+          <code>example/.env</code>:
+        </p>
+        <pre
+          style={{
+            background: '#0f172a',
+            color: '#e2e8f0',
+            padding: 12,
+            borderRadius: 6,
+            fontSize: 12,
+            overflowX: 'auto',
+          }}
+        >
+          UNIFY_ADMIN_API_KEY=… ./grant-handoff/mint-session.sh
+        </pre>
+        <p>
+          then restart <code>yarn start</code>. See{' '}
+          <code>grant-handoff/README.md</code>.
+        </p>
+      </div>
+    )}
+
+    <StatusPanel />
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/opener-severed-confirm/README.md
+++ b/example/opener-severed-confirm/README.md
@@ -1,0 +1,114 @@
+# `window.opener` severed confirm handoff — real cross-origin iframe repro (OCTA)
+
+Reproduces the production failure the storage harness (`../iframe-test/`)
+explicitly does **not** cover: an OAuth connection stuck at `state: authorized`
+/ `health: pending_confirmation` with no `vault.connection.callable` webhook,
+because the client-driven `POST /confirm` never fires.
+
+## Why it breaks
+
+After OAuth, vault's callback page forwards the `confirm_token` to the widget
+**only** via:
+
+```js
+if (nonce && confirm_token && service_id && window.opener) { window.opener.postMessage(...) }
+// vault/src/pages/oauth/callback.tsx:17 — else the token is silently dropped
+```
+
+When the widget is nested in cross-origin iframes (OCTA: OctaFlow → iframe →
+OctaCore → iframe → vaultjs), the OAuth popup can end up with `window.opener ===
+null` — so the guard is skipped, `POST /confirm` never runs, and the connection
+stays `pending_confirmation`.
+
+## What makes this repro "proper"
+
+The previous version monkey-patched `window.open` to force `noopener`. That
+faked the symptom but also nulled the `window.open` return handle, so the
+Authorize button spun forever instead of resetting — not what production does.
+
+This version induces the **real** browser condition instead:
+
+- **Genuine cross-origin nesting.** One Vite dev server, three loopback origins
+  (`localhost` → `[::1]` → `127.0.0.1`) so `outer.html` embeds `middle.html`
+  embeds `widget.html` across real origin boundaries, mirroring OCTA's chain.
+- **Real COOP severance, no JS override.** The OAuth popup's landing page is
+  served with `Cross-Origin-Opener-Policy: same-origin` in severed mode (a Vite
+  dev-server middleware — see `vite.config.ts`). Because that page is
+  cross-origin to the widget that opened it, the browser puts the popup in its
+  own browsing-context group and `window.opener` becomes `null`. COOP is ignored
+  on iframe documents and we don't control the real vault callback's headers, so
+  the popup's own landing page is the lever that genuinely applies — and it's the
+  same header a provider or vault page can set in production, which is exactly
+  why the failure is "spotty" across accounts.
+
+### Two things run on the widget page
+
+1. **The real `<Vault>`** (`@apideck/react-vault`) against **real Unify** — set a
+   JWT to drive the full OAuth → confirm flow. Whether the *real* vault callback
+   keeps its opener is environment-dependent (the production "spotty").
+2. **An opener probe** — the deterministic demonstrator. It replays the shape
+   of vault's `oauth/callback` handoff (`window.open` →
+   `window.opener.postMessage(token)`) against our own `probe.html`, whose COOP
+   header we control. **No OAuth login required.** In severed mode the popup's
+   `window.opener` is null, the message is dropped, and the widget shows exactly
+   what strands the connection. Note the probe uses its own message type and
+   listener — it demonstrates the browser mechanism, not vault-core's code path
+   (only the real `<Vault>` above exercises that). The severance also doesn't
+   depend on the iframe nesting: COOP on the popup's landing page severs the
+   opener even for a top-level widget. The nesting mirrors OCTA's embedding and
+   matters for the real `<Vault>` path (CORS, storage partitioning), not for
+   the probe.
+
+## Run
+
+The example imports the built `../../dist`, so build the library first.
+
+```bash
+# repo root
+yarn build
+
+cd example
+cp .env.example .env      # optional — only needed to drive the real <Vault>
+yarn install
+yarn start                # serves on http://localhost:1234 (or next free port)
+```
+
+Open the **top-level host on `localhost`** (the origins assume it):
+
+- **Working:** http://localhost:1234/opener-severed-confirm/outer.html?opener=intact
+- **OCTA bug:** http://localhost:1234/opener-severed-confirm/outer.html?opener=severed
+
+Click **Test opener handoff** and watch the widget banner:
+
+- `?opener=intact` → popup keeps its opener → **DELIVERED ✅** → `/confirm` would fire → `callable`.
+- `?opener=severed` → popup's `window.opener` is null → **DROPPED ❌** → `/confirm` never fires → stuck `pending_confirmation`.
+
+Allow popups for the host. To also exercise the real `<Vault>` OAuth flow, set
+`VITE_VAULT_TOKEN` in `example/.env` (an account in unify's `oauthCsrf` allowlist,
+an OAuth connector such as `accounting/xero` or `accounting/quickbooks`).
+
+## Files
+
+| File | Origin | Role |
+|---|---|---|
+| `outer.html` / `outer.tsx` | `localhost` | OctaFlow — top-level host, mode toggle |
+| `middle.html` / `middle.tsx` | `[::1]` | OctaCore — middle cross-origin iframe |
+| `widget.html` / `widget.tsx` | `127.0.0.1` | vaultjs — real `<Vault>` + opener probe |
+| `probe.html` / `probe.tsx` | `localhost` | stands in for vault's `oauth/callback`; COOP toggled here |
+| `origins.ts` | — | shared origin/mode helpers |
+
+## Notes
+
+- If `[::1]` (IPv6 loopback) isn't served in your environment, adjust the
+  hostnames in `origins.ts` — any three distinct origins work.
+- The real `<Vault>` on `127.0.0.1` needs Unify to allow that Origin (CORS); the
+  probe demonstrator does not depend on Unify at all.
+
+## The fix (see the plan)
+
+`../../../unify/thoughts/shared/plans/2026-07-13-vault-oauth-csrf-confirm-handoff-fix.md`
+and the problem/requirements writeup at
+`../../thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md`.
+The security-critical constraint: the confirm secret must be minted
+post-completion and delivered only to the initiating context — which is exactly
+the `window.opener` channel this harness severs.

--- a/example/opener-severed-confirm/middle.html
+++ b/example/opener-severed-confirm/middle.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>opener severed confirm — OctaCore (middle iframe)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./middle.tsx"></script>
+  </body>
+</html>

--- a/example/opener-severed-confirm/middle.tsx
+++ b/example/opener-severed-confirm/middle.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { ORIGINS, readMode } from './origins';
+
+// Middle iframe ("OctaCore"), served from [::1] — cross-origin to both the
+// top-level host (localhost) and the widget it embeds (127.0.0.1). Its only job
+// is to add a second cross-origin boundary above the widget, matching OCTA's
+// OctaFlow → OctaCore → vaultjs nesting.
+
+const mode = readMode();
+const widgetSrc = `${ORIGINS.widget}/opener-severed-confirm/widget.html?opener=${mode}`;
+
+const App = () => (
+  <div style={{ margin: 0, fontFamily: 'system-ui' }}>
+    <div
+      style={{
+        padding: '4px 12px',
+        font: '11px/1.4 system-ui',
+        color: '#334155',
+        background: '#e2e8f0',
+      }}
+    >
+      middle iframe · <code>{ORIGINS.middle}</code> (cross-origin to host and
+      widget)
+    </div>
+    <iframe
+      title="widget (vaultjs)"
+      src={widgetSrc}
+      style={{ width: '100%', height: 'calc(100vh - 84px)', border: 'none' }}
+    />
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/opener-severed-confirm/origins.ts
+++ b/example/opener-severed-confirm/origins.ts
@@ -1,0 +1,36 @@
+// Three distinct origins served by the ONE Vite dev server (see vite.config.ts
+// `server.host: true`). Different hostnames = different origins, so nesting
+// outer → middle → widget gives genuine cross-origin iframe boundaries, and the
+// widget → probe popup is cross-origin too — the conditions COOP needs to sever
+// window.opener. Port is inherited from wherever the page was opened.
+//
+//   outer  (localhost)   OctaFlow — top-level host, carries the COOP lever
+//   middle ([::1])       OctaCore — middle cross-origin iframe
+//   widget (127.0.0.1)   vaultjs  — inner cross-origin iframe, real <Vault>
+//   probe  (localhost)   stands in for vault's oauth/callback popup
+//
+// The real <Vault> lives on 127.0.0.1 (not the IPv6 literal) so its Unify API
+// calls carry a friendlier Origin; the probe demonstrator needs no such luck.
+//
+// Open the harness via http://localhost:<port>/opener-severed-confirm/outer.html
+// so `outer` is the localhost origin these URLs assume.
+const PORT =
+  typeof window !== 'undefined' && window.location.port
+    ? window.location.port
+    : '1234';
+
+export const ORIGINS = {
+  outer: `http://localhost:${PORT}`,
+  middle: `http://[::1]:${PORT}`,
+  widget: `http://127.0.0.1:${PORT}`,
+  probe: `http://localhost:${PORT}`,
+};
+
+export type OpenerMode = 'intact' | 'severed';
+
+export function readMode(): OpenerMode {
+  const m = new URLSearchParams(window.location.search).get('opener');
+  return m === 'severed' ? 'severed' : 'intact';
+}
+
+export const PROBE_MESSAGE = 'opener-severed-probe';

--- a/example/opener-severed-confirm/outer.html
+++ b/example/opener-severed-confirm/outer.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>opener severed confirm — OctaFlow (top-level host)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./outer.tsx"></script>
+  </body>
+</html>

--- a/example/opener-severed-confirm/outer.tsx
+++ b/example/opener-severed-confirm/outer.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { ORIGINS, readMode } from './origins';
+
+// Top-level host page ("OctaFlow"). It embeds the middle frame from a DIFFERENT
+// origin ([::1]), which in turn embeds the widget from a third origin
+// (127.0.0.1) — reproducing OCTA's nested cross-origin iframe chain with real
+// browser isolation, not a window.open override.
+//
+// The ?opener=severed | intact mode is threaded down to every frame via the
+// iframe src query, and (for severed) the Vite dev middleware attaches
+// `Cross-Origin-Opener-Policy: same-origin` to the popup's landing page so the
+// popup's window.opener is genuinely null.
+
+const mode = readMode();
+const severed = mode === 'severed';
+const middleSrc = `${ORIGINS.middle}/opener-severed-confirm/middle.html?opener=${mode}`;
+
+const link = (m: string, label: string) => (
+  <a
+    href={`?opener=${m}`}
+    style={{
+      color: '#fff',
+      fontWeight: mode === m ? 700 : 400,
+      textDecoration: mode === m ? 'underline' : 'none',
+    }}
+  >
+    {label}
+  </a>
+);
+
+const App = () => (
+  <div style={{ fontFamily: 'system-ui', margin: 0 }}>
+    <div
+      style={{
+        padding: '10px 16px',
+        color: '#fff',
+        background: severed ? '#b91c1c' : '#15803d',
+        font: '13px/1.5 system-ui',
+      }}
+    >
+      <strong>
+        window.opener: {severed ? 'SEVERED (COOP: same-origin)' : 'intact'}
+      </strong>{' '}
+      — top <code>{ORIGINS.outer}</code> ▸ iframe <code>{ORIGINS.middle}</code>{' '}
+      ▸ iframe <code>{ORIGINS.widget}</code> · {link('intact', 'intact')} |{' '}
+      {link('severed', 'severed (OCTA)')}
+      <div style={{ marginTop: 4, opacity: 0.9 }}>
+        {severed
+          ? 'The OAuth popup lands on a page served with COOP: same-origin, cross-origin to the widget → window.opener is null → vault would drop the confirm_token → stuck pending_confirmation.'
+          : 'The OAuth popup keeps its opener → vault postMessages the confirm_token back → widget calls /confirm → callable.'}
+      </div>
+    </div>
+    <iframe
+      title="middle (OctaCore)"
+      src={middleSrc}
+      style={{ width: '100%', height: 'calc(100vh - 62px)', border: 'none' }}
+    />
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/opener-severed-confirm/probe.html
+++ b/example/opener-severed-confirm/probe.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>opener probe — stands in for vault oauth/callback</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./probe.tsx"></script>
+  </body>
+</html>

--- a/example/opener-severed-confirm/probe.tsx
+++ b/example/opener-severed-confirm/probe.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { PROBE_MESSAGE, readMode } from './origins';
+
+// This page stands in for vault's real oauth/callback (vault/src/pages/oauth/
+// callback.tsx). It runs the identical guarded handoff:
+//
+//   if (window.opener) window.opener.postMessage({ confirm_token, ... }, '*')
+//   else               // token silently dropped
+//
+// It is opened as a popup by the widget ([::1]) and is itself served from
+// localhost — cross-origin to the opener. In `?opener=severed` the Vite dev
+// middleware serves THIS page with `Cross-Origin-Opener-Policy: same-origin`;
+// because the opener is cross-origin, the browser puts the popup in its own
+// browsing-context group and `window.opener` is null. No JS override — this is
+// the real COOP mechanism, and it's the same header a provider/vault page can
+// set in production to cause the "spotty" OCTA failure.
+
+const mode = readMode();
+const hasOpener = !!window.opener;
+
+// Mirror the callback guard exactly.
+if (hasOpener) {
+  window.opener.postMessage(
+    {
+      type: PROBE_MESSAGE,
+      confirmToken: 'probe-confirm-token',
+      serviceId: 'probe',
+      success: true,
+    },
+    '*'
+  );
+}
+
+const App = () => (
+  <div style={{ fontFamily: 'system-ui', padding: 24 }}>
+    <h2 style={{ marginTop: 0 }}>OAuth callback (probe)</h2>
+    <div
+      style={{
+        padding: '10px 14px',
+        borderRadius: 6,
+        color: '#fff',
+        background: hasOpener ? '#15803d' : '#b91c1c',
+      }}
+    >
+      <strong>
+        window.opener is {hasOpener ? 'LIVE' : 'null'} (mode: {mode})
+      </strong>
+      <div style={{ marginTop: 6, fontSize: 13, opacity: 0.95 }}>
+        {hasOpener
+          ? 'Posted the confirm_token back to the opener — the widget receives it and would call POST /confirm.'
+          : 'No opener to postMessage to → the confirm_token is dropped, just like vault/src/pages/oauth/callback.tsx. The connection would stay pending_confirmation.'}
+      </div>
+    </div>
+    <p style={{ fontSize: 13, color: '#475569' }}>
+      You can close this window.
+    </p>
+    <button onClick={() => window.close()} style={{ padding: '6px 12px' }}>
+      Close
+    </button>
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+
+// In the working case, auto-close shortly after handing back the token so the
+// popup behaves like the real callback (which calls window.close()).
+if (hasOpener) {
+  window.setTimeout(() => window.close(), 1200);
+}

--- a/example/opener-severed-confirm/widget.html
+++ b/example/opener-severed-confirm/widget.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>opener severed confirm — vaultjs (widget iframe)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./widget.tsx"></script>
+  </body>
+</html>

--- a/example/opener-severed-confirm/widget.tsx
+++ b/example/opener-severed-confirm/widget.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Vault } from '../../.';
+import '../../dist/styles.css';
+import { ORIGINS, PROBE_MESSAGE, readMode } from './origins';
+
+// The innermost frame ("vaultjs"), served from 127.0.0.1 — nested two cross-origin
+// iframes deep (see outer.tsx / middle.tsx). It renders the REAL
+// @apideck/react-vault <Vault> against the REAL Unify service. Nothing about
+// window.open is patched here — the opener severance is produced by real
+// browser isolation (COOP on the popup's landing page), exactly as in OCTA.
+//
+// Two things run on this page:
+//
+// 1. The real <Vault>. If you have a JWT (example/.env) you can drive the full
+//    OAuth → confirm flow. Whether the REAL vault callback's opener survives is
+//    environment-dependent (that's the production "spotty"); the probe below
+//    makes the failure deterministic without a login.
+//
+// 2. An opener probe. It replays the SHAPE of vault's oauth/callback handoff —
+//    open a cross-origin popup, then `window.opener.postMessage(token)` — but
+//    against our own probe.html, whose COOP header we control, and with its own
+//    message type so the real <Vault> listener never sees it. It demonstrates
+//    the browser mechanism, not vault-core's code path: in severed mode the
+//    popup's window.opener is null, the message is dropped, and the widget
+//    shows exactly what would strand the connection at pending_confirmation.
+
+const { useEffect, useRef, useState } = React;
+
+const mode = readMode();
+const severed = mode === 'severed';
+
+const env = (import.meta as any).env ?? {};
+const token: string = env.VITE_VAULT_TOKEN ?? '';
+const unifiedApi: string = env.VITE_VAULT_UNIFIED_API ?? 'crm';
+const serviceId: string = env.VITE_VAULT_SERVICE_ID ?? 'hubspot';
+const unifyBaseUrl: string | undefined =
+  env.VITE_VAULT_UNIFY_BASE_URL || undefined;
+
+type ProbeResult = 'idle' | 'pending' | 'delivered' | 'dropped';
+
+const OpenerProbe = () => {
+  const [result, setResult] = useState<ProbeResult>('idle');
+  const resultRef = useRef<ProbeResult>('idle');
+  resultRef.current = result;
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if ((event.data as any)?.type === PROBE_MESSAGE) {
+        setResult('delivered');
+      }
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
+
+  const runProbe = () => {
+    setResult('pending');
+    // Cross-origin to this widget ([::1] → localhost) and, in severed mode,
+    // served with COOP: same-origin — the exact shape of vault's real callback.
+    const url = `${ORIGINS.probe}/opener-severed-confirm/probe.html?opener=${mode}`;
+    window.open(url, 'opener-probe', 'width=520,height=600');
+    // No opener message within the grace window ⇒ it was dropped (severed).
+    window.setTimeout(() => {
+      if (resultRef.current === 'pending') setResult('dropped');
+    }, 3000);
+  };
+
+  const status: Record<ProbeResult, { text: string; color: string }> = {
+    idle: { text: 'not run yet', color: '#475569' },
+    pending: { text: 'waiting for the popup to hand back the token…', color: '#b45309' },
+    delivered: {
+      text: 'DELIVERED ✅ — window.opener was live, postMessage arrived, /confirm would fire',
+      color: '#15803d',
+    },
+    dropped: {
+      text: 'DROPPED ❌ — window.opener was null in the popup, token lost, /confirm never fires → stuck pending_confirmation',
+      color: '#b91c1c',
+    },
+  };
+
+  return (
+    <div
+      style={{
+        border: '1px solid #e2e8f0',
+        borderRadius: 8,
+        padding: 16,
+        marginBottom: 16,
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+        Opener handoff probe (no login required)
+      </div>
+      <p style={{ margin: '0 0 12px', fontSize: 13, color: '#475569' }}>
+        Replays the shape of vault's <code>oauth/callback</code> handoff
+        against <code>probe.html</code> — opens a cross-origin popup, then{' '}
+        <code>window.opener.postMessage(token)</code>. Demonstrates the browser
+        mechanism (no OAuth login needed); it does not exercise the real{' '}
+        <code>&lt;Vault&gt;</code> listener.
+      </p>
+      <button onClick={runProbe} style={{ padding: '8px 14px', cursor: 'pointer' }}>
+        Test opener handoff
+      </button>
+      <div style={{ marginTop: 12, fontSize: 13, color: status[result].color }}>
+        <strong>Handoff:</strong> {status[result].text}
+      </div>
+    </div>
+  );
+};
+
+const App = () => (
+  <div style={{ fontFamily: 'system-ui', padding: 16 }}>
+    <div
+      style={{
+        padding: '8px 12px',
+        color: '#fff',
+        borderRadius: 6,
+        marginBottom: 16,
+        background: severed ? '#b91c1c' : '#15803d',
+        fontSize: 13,
+      }}
+    >
+      <strong>vaultjs</strong> · <code>{ORIGINS.widget}</code> · opener{' '}
+      <strong>{severed ? 'SEVERED' : 'intact'}</strong> · real Unify{' '}
+      <code>{unifyBaseUrl ?? 'https://unify.apideck.com'}</code>
+    </div>
+
+    <OpenerProbe />
+
+    {token ? (
+      <Vault
+        token={token}
+        open
+        unifiedApi={unifiedApi}
+        serviceId={serviceId}
+        unifyBaseUrl={unifyBaseUrl}
+        showButtonLayout
+      />
+    ) : (
+      <div style={{ fontSize: 14, color: '#334155' }}>
+        <p>
+          No <code>VITE_VAULT_TOKEN</code> set — the probe above still
+          demonstrates the opener severance. To also drive the real{' '}
+          <code>&lt;Vault&gt;</code> OAuth flow, set a JWT in{' '}
+          <code>example/.env</code> (an account in unify's <code>oauthCsrf</code>{' '}
+          allowlist, OAuth connector) and restart <code>yarn start</code>.
+        </p>
+      </div>
+    )}
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/storage-roundtrip/README.md
+++ b/example/storage-roundtrip/README.md
@@ -1,0 +1,142 @@
+# sessionStorage round-trip experiment — step 0 of the confirm-handoff fix
+
+Empirically tests the **single unverified assumption** of the proposed fix for
+the OAuth confirm handoff (the failure reproduced in
+`../opener-severed-confirm/`): connections stuck at `pending_confirmation`
+because COOP on the popup's navigation chain severs `window.opener`, the only
+channel that delivers the `confirm_token` today.
+
+## The proposed fix, in one paragraph
+
+Instead of carrying the secret **backwards** (popup → widget) **after** OAuth
+completes — through an opener link that third-party COOP may have destroyed —
+carry a single-use **grant forwards** (widget → popup) **at open time**, when
+the opener link is guaranteed alive because the popup's first page is a
+vault-origin launcher whose headers we control. The launcher stores the grant
+in the tab's vault-origin `sessionStorage`; after the provider redirect chain,
+the vault-origin callback reads it back and **self-confirms in-tab** (grant +
+`confirm_token`). Nothing ever needs to travel back into the nested iframe.
+Security is preserved because the grant only enters a popup through a live
+opener handshake (a handed-out URL can never carry it) and is useless without
+the `confirm_token` minted post-completion inside the completer's tab.
+
+## The question this harness answers
+
+> Does a tab's vault-origin `sessionStorage` survive the browsing-context-group
+> swaps that `COOP: same-origin` pages cause mid-navigation-chain?
+
+If **yes** (expected per spec — session storage is keyed to the tab's session,
+not the browsing-context group): the design is viable. If **no** on any major
+browser: the design is falsified before anything is built. That's the go/no-go.
+
+## What one run does
+
+```
+widget (127.0.0.1, cross-origin iframe under localhost host)
+  │ window.open ──────────────► launch.html   (localhost = "vault", NO COOP)
+  │ ◄── ready ping (opener LIVE)     │
+  │ ──── grant via postMessage ────► │  stores grant in sessionStorage,
+  │      (explicit targetOrigin)     │  navigates the tab:
+  │                                  ▼
+  │                              provider.html ([::1], COOP: same-origin when
+  │                                  │           severed → context-group swap,
+  │                                  │           opener dies here)
+  │                                  ▼
+  │                              callback.html (localhost = "vault" again,
+  │                                  │           also COOP-served when severed)
+  │                                  │  reads grant from sessionStorage,
+  │                                  │  checks window.opener,
+  │                                  │  POSTs verdict to the dev server
+  │                                  ▼
+  └── polls /storage-roundtrip/api/result ◄──── (the production analog:
+      and shows GO / NO-GO                       widget polls unify)
+```
+
+The run id in URLs is a non-secret correlation id. The grant **never** appears
+in a URL — that rule is security-load-bearing in the real design, so the
+harness observes it too.
+
+## Run
+
+```bash
+cd example
+yarn install
+yarn start        # http://localhost:1234 (or next free port)
+```
+
+Open the host on **localhost** (the origins assume it), allow popups:
+
+- **Control:** http://localhost:1234/storage-roundtrip/host.html?opener=intact
+- **The experiment:** http://localhost:1234/storage-roundtrip/host.html?opener=severed
+
+Click **Run experiment**, watch the popup walk the chain, then read the widget
+banner:
+
+| Mode | Expected result |
+|---|---|
+| `intact` | opener LIVE at callback, grant survived — both channels work |
+| `severed` | opener **null** at callback (today's flow would drop the token) but grant **survived** → **GO ✅** |
+| any | grant missing at callback → **NO-GO ❌** — design falsified on that browser; record the reported user agent |
+
+Repeat the severed run in **Chrome, Safari, and Firefox** (and once in private
+mode per browser) before calling it a GO.
+
+### Safari note
+
+Safari cannot load literal-IPv6 URLs (`http://[::1]:…`) — a WebKit/Safari
+networking limitation Chrome, Firefox and DuckDuckGo don't share. On
+Safari-like browsers the harness auto-falls back to `127.0.0.1` for the
+provider hop (see `shared.ts`). The provider then shares the widget's origin,
+which is cosmetically less realistic but mechanically irrelevant: the tested
+storage bucket is the popup tab's `localhost` (vault) one, and `127.0.0.1` is
+still cross-origin to it, so the COOP context-group swap still happens. The
+widget banner shows which provider origin is active. The popup chain also
+posts per-hop progress reports, so a stall names its last completed hop
+instead of hanging silently.
+
+### Results so far (severed mode)
+
+| Browser | Engine | Result |
+|---|---|---|
+| Chromium (headless, Playwright) | Blink | **GO ✅** — opener dead, grant survived |
+| Firefox | Gecko | **GO ✅** — opener dead, grant survived |
+| DuckDuckGo (macOS) | WebKit | **GO ✅** — opener dead, grant survived |
+| Safari | WebKit | **GO ✅** — opener dead, grant survived (via the `127.0.0.1` provider fallback; the first run stalled only on Safari's inability to load the `[::1]` origin) |
+
+**Verdict: GO on all three engines (Blink, Gecko, WebKit).** The design's core
+assumption — vault-origin sessionStorage surviving COOP browsing-context-group
+swaps within the popup tab — holds everywhere. Remaining nice-to-have: repeat
+once per browser in private mode.
+
+## What else the harness demonstrates
+
+- **Launcher guardrails:** open `launch.html` directly (no opener) — it refuses
+  to start the flow. That's the anti-phishing property: a handed-out launcher
+  link goes nowhere. It also write-read probes sessionStorage before relying
+  on it.
+- **Grant invisibility:** the provider page shows it cannot read the grant
+  (different origin → different sessionStorage bucket).
+- **The full proposed flow shape end-to-end:** open-time handshake in, storage
+  across, server-side confirm out, widget polls — each stand-in maps 1:1 to a
+  production piece (launcher → vault `oauth/launch`, report POST → in-tab
+  `POST /confirm`, result polling → connection-state polling at unify).
+
+## Files
+
+| File | Origin | Stands in for |
+|---|---|---|
+| `host.html` / `host.tsx` | `localhost` | customer top-level page |
+| `widget.html` / `widget.tsx` | `127.0.0.1` | embedded vault-core widget |
+| `launch.html` / `launch.tsx` | `localhost` | proposed vault `oauth/launch` |
+| `provider.html` / `provider.tsx` | `[::1]` | OAuth provider (COOP lever) |
+| `callback.html` / `callback.tsx` | `localhost` | vault `oauth/callback` self-confirm |
+| `shared.ts` | — | origins, message types, report client |
+
+COOP headers and the report API live in `../vite.config.ts`
+(`storageRoundtripPlugin`).
+
+## Related
+
+- Today's failure repro: `../opener-severed-confirm/`
+- Problem & requirements: `../../thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md`
+- Prior plan this supersedes in part: `../../../unify/thoughts/shared/plans/2026-07-13-vault-oauth-csrf-confirm-handoff-fix.md`

--- a/example/storage-roundtrip/callback.html
+++ b/example/storage-roundtrip/callback.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>callback — proposed in-tab self-confirm stand-in</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./callback.tsx"></script>
+  </body>
+</html>

--- a/example/storage-roundtrip/callback.tsx
+++ b/example/storage-roundtrip/callback.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { postReport, readMode, readRun, storageKey } from './shared';
+
+// Stand-in for the proposed vault `oauth/callback` behaviour: back on the
+// vault origin (localhost), SAME TAB, after the COOP-serving provider. It
+// answers the experiment's question directly:
+//
+//   - window.opener — today's channel. Expected NULL in severed mode (the
+//     confirm_token would have been dropped right here).
+//   - sessionStorage grant — the proposed channel. If it survived the
+//     browsing-context-group swaps, the in-tab self-confirm works.
+//
+// The report POST is the stand-in for the in-tab `POST /confirm`
+// (grant + confirm_token), and it is also how the widget — which nothing in
+// this tab can reach directly — learns the verdict, exactly as the production
+// widget would learn it by polling unify. In severed mode this page is itself
+// served with COOP too (another context-group swap), since we don't control
+// the real callback's effective policy either.
+
+const mode = readMode();
+const run = readRun();
+
+const openerAlive = !!window.opener;
+
+let storageReadable = true;
+let grant: string | null = null;
+try {
+  const raw = sessionStorage.getItem(storageKey(run));
+  if (raw) {
+    grant = (JSON.parse(raw) as { grant?: string }).grant ?? null;
+    // Single-use, like the real confirm secret.
+    sessionStorage.removeItem(storageKey(run));
+  }
+} catch {
+  storageReadable = false;
+}
+
+const grantSurvived = !!grant;
+
+postReport({
+  run,
+  mode,
+  stage: 'callback',
+  ok: grantSurvived,
+  grantSurvived,
+  grant,
+  openerAlive,
+  storageReadable,
+  userAgent: navigator.userAgent,
+});
+
+const verdict = grantSurvived
+  ? mode === 'severed' && !openerAlive
+    ? {
+        color: '#15803d',
+        title: 'GO ✅ — proposed channel works where today’s is dead',
+        detail:
+          'window.opener is null (today’s flow would drop the confirm_token here), but the grant survived the COOP browsing-context-group swaps in this tab’s vault-origin sessionStorage. The in-tab self-confirm just “fired” (reported to the dev server).',
+      }
+    : {
+        color: '#15803d',
+        title: 'Grant survived ✅',
+        detail: `sessionStorage carried the grant through the chain. window.opener is ${
+          openerAlive ? 'also alive (intact mode — both channels work)' : 'null'
+        }.`,
+      }
+  : {
+      color: '#b91c1c',
+      title: 'NO-GO ❌ — grant did not survive',
+      detail: storageReadable
+        ? 'sessionStorage was readable but the grant was gone after the navigation chain. On this browser the design’s core assumption is falsified — record the user agent below.'
+        : 'sessionStorage was not readable at the callback (blocked storage?). Production would need the legacy opener fallback here.',
+    };
+
+// Mirror the real callback: close shortly after a successful self-confirm;
+// stay open on failure so the evidence can be inspected.
+if (grantSurvived) {
+  window.setTimeout(() => window.close(), 5000);
+}
+
+const App = () => (
+  <div style={{ fontFamily: 'system-ui', padding: 24 }}>
+    <h2 style={{ marginTop: 0 }}>Callback (proposed in-tab self-confirm)</h2>
+    <div
+      style={{
+        padding: '10px 14px',
+        borderRadius: 6,
+        color: '#fff',
+        background: verdict.color,
+      }}
+    >
+      <strong>{verdict.title}</strong>
+      <div style={{ marginTop: 6, fontSize: 13, opacity: 0.95 }}>
+        {verdict.detail}
+      </div>
+    </div>
+    <table style={{ marginTop: 16, fontSize: 13, color: '#334155' }}>
+      <tbody>
+        <tr>
+          <td style={{ paddingRight: 12 }}>mode</td>
+          <td>
+            <code>{mode}</code>
+          </td>
+        </tr>
+        <tr>
+          <td style={{ paddingRight: 12 }}>window.opener (today’s channel)</td>
+          <td>
+            <strong>{openerAlive ? 'LIVE' : 'null'}</strong>
+          </td>
+        </tr>
+        <tr>
+          <td style={{ paddingRight: 12 }}>grant via sessionStorage</td>
+          <td>
+            <strong>{grantSurvived ? `survived (${grant})` : 'MISSING'}</strong>
+          </td>
+        </tr>
+        <tr>
+          <td style={{ paddingRight: 12 }}>user agent</td>
+          <td>
+            <code style={{ fontSize: 11 }}>{navigator.userAgent}</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p style={{ fontSize: 13, color: '#475569' }}>
+      {grantSurvived
+        ? 'This window closes itself in a few seconds, like the real callback.'
+        : 'Left open for inspection.'}
+    </p>
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/storage-roundtrip/host.html
+++ b/example/storage-roundtrip/host.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>storage round-trip experiment — host</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./host.tsx"></script>
+  </body>
+</html>

--- a/example/storage-roundtrip/host.tsx
+++ b/example/storage-roundtrip/host.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { ORIGINS, readMode } from './shared';
+
+// Top-level customer-page stand-in (localhost). Embeds the widget from a
+// different origin (127.0.0.1) so the widget → popup handshake crosses a real
+// origin boundary, like an embedded vault-core widget. Deeper nesting is
+// deliberately omitted: ../opener-severed-confirm/ already established that
+// nesting depth is irrelevant to opener severance, and it is equally
+// irrelevant to what happens inside the popup tab.
+
+const mode = readMode();
+const severed = mode === 'severed';
+const widgetSrc = `${ORIGINS.widget}/storage-roundtrip/widget.html?opener=${mode}`;
+
+const link = (m: string, label: string) => (
+  <a
+    href={`?opener=${m}`}
+    style={{
+      color: '#fff',
+      fontWeight: mode === m ? 700 : 400,
+      textDecoration: mode === m ? 'underline' : 'none',
+    }}
+  >
+    {label}
+  </a>
+);
+
+const App = () => (
+  <div style={{ fontFamily: 'system-ui', margin: 0 }}>
+    <div
+      style={{
+        padding: '10px 16px',
+        color: '#fff',
+        background: severed ? '#b91c1c' : '#15803d',
+        font: '13px/1.5 system-ui',
+      }}
+    >
+      <strong>
+        sessionStorage round-trip experiment · popup chain COOP:{' '}
+        {severed ? 'same-origin (severed)' : 'none (intact)'}
+      </strong>{' '}
+      — {link('intact', 'intact')} | {link('severed', 'severed (the OCTA condition)')}
+      <div style={{ marginTop: 4, opacity: 0.9 }}>
+        Tests the proposed confirm-handoff fix: grant handed into the popup at
+        open time, stored in the tab’s vault-origin sessionStorage, read back
+        by the callback after {severed ? 'COOP-swapping' : 'plain'} cross-origin
+        navigations. Expected in severed mode: opener DEAD, grant ALIVE.
+      </div>
+    </div>
+    <iframe
+      title="widget"
+      src={widgetSrc}
+      style={{ width: '100%', height: 'calc(100vh - 78px)', border: 'none' }}
+    />
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/storage-roundtrip/launch.html
+++ b/example/storage-roundtrip/launch.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>launcher — proposed vault oauth/launch stand-in</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./launch.tsx"></script>
+  </body>
+</html>

--- a/example/storage-roundtrip/launch.tsx
+++ b/example/storage-roundtrip/launch.tsx
@@ -1,0 +1,176 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {
+  GRANT_MESSAGE,
+  ORIGINS,
+  READY_MESSAGE,
+  postReport,
+  readMode,
+  readRun,
+  storageKey,
+} from './shared';
+
+// Stand-in for the proposed vault `oauth/launch` page — the popup's FIRST
+// document, on the vault origin (localhost), served WITHOUT COOP. Because we
+// control this page's headers, `window.opener` is intact here by construction,
+// even in severed mode: severance only happens later, when the tab navigates
+// through the COOP-serving provider stand-in.
+//
+// Sequence (mirrors the proposed design exactly):
+//   1. refuse to proceed without an opener — the anti-phishing guardrail: a
+//      bare handed-out link to this page must go nowhere
+//   2. write-read probe sessionStorage (feature detection)
+//   3. announce readiness to the opener (the ping carries no secret), receive
+//      the grant via postMessage — never via URL
+//   4. store the grant in this tab's vault-origin sessionStorage
+//   5. navigate the tab to the provider
+
+const mode = readMode();
+const run = readRun();
+
+const { useEffect, useState } = React;
+
+type Status =
+  | 'starting'
+  | 'no-opener'
+  | 'no-storage'
+  | 'waiting-grant'
+  | 'grant-timeout'
+  | 'navigating';
+
+const App = () => {
+  const [status, setStatus] = useState<Status>('starting');
+
+  useEffect(() => {
+    // Guardrail 1: no opener ⇒ no flow. In production this is what makes a
+    // phished launcher link useless — and what a customer top-level page with
+    // COOP: same-origin would trip, loudly, before any consent screen.
+    if (!window.opener) {
+      setStatus('no-opener');
+      postReport({ run, mode, stage: 'launch', ok: false, reason: 'no-opener' });
+      return;
+    }
+
+    // Guardrail 2: storage must demonstrably work before we rely on it.
+    try {
+      sessionStorage.setItem(storageKey('selftest'), '1');
+      if (sessionStorage.getItem(storageKey('selftest')) !== '1') {
+        throw new Error('write-read mismatch');
+      }
+      sessionStorage.removeItem(storageKey('selftest'));
+    } catch {
+      setStatus('no-storage');
+      postReport({
+        run,
+        mode,
+        stage: 'launch',
+        ok: false,
+        reason: 'storage-unavailable',
+      });
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setStatus('grant-timeout');
+      postReport({
+        run,
+        mode,
+        stage: 'launch',
+        ok: false,
+        reason: 'grant-timeout',
+      });
+    }, 5000);
+
+    const onMessage = (event: MessageEvent) => {
+      const data = event.data as any;
+      if (
+        data?.type !== GRANT_MESSAGE ||
+        data.run !== run ||
+        typeof data.grant !== 'string'
+      ) {
+        return;
+      }
+      window.clearTimeout(timeout);
+      window.removeEventListener('message', onMessage);
+      // From here the grant lives ONLY in this tab's vault-origin
+      // sessionStorage — the provider (different origin, different bucket)
+      // cannot read it, and no URL ever carries it.
+      sessionStorage.setItem(
+        storageKey(run),
+        JSON.stringify({ grant: data.grant, storedAt: window.location.origin })
+      );
+      setStatus('navigating');
+      // Progress ping: if the chain stalls after this (e.g. the provider
+      // origin doesn't load in this browser), the widget can say so.
+      postReport({
+        run,
+        mode,
+        stage: 'launch',
+        ok: true,
+        reason: `navigating to ${ORIGINS.provider}`,
+      });
+      window.location.replace(
+        `${ORIGINS.provider}/storage-roundtrip/provider.html?opener=${mode}&run=${run}`
+      );
+    };
+    window.addEventListener('message', onMessage);
+
+    (window.opener as Window).postMessage({ type: READY_MESSAGE, run }, '*');
+    setStatus('waiting-grant');
+
+    return () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener('message', onMessage);
+    };
+  }, []);
+
+  const text: Record<Status, { msg: string; color: string }> = {
+    starting: { msg: 'starting…', color: '#475569' },
+    'no-opener': {
+      msg:
+        'REFUSED — window.opener is null at launch, so no grant can be delivered and the flow must not start. (Phished launcher link, or COOP on the embedding page itself.)',
+      color: '#b91c1c',
+    },
+    'no-storage': {
+      msg:
+        'REFUSED — sessionStorage is unavailable. Production would fall back to the legacy opener path instead of proceeding.',
+      color: '#b91c1c',
+    },
+    'waiting-grant': {
+      msg: 'opener is LIVE — announced ready, waiting for the grant handshake…',
+      color: '#b45309',
+    },
+    'grant-timeout': {
+      msg: 'no grant arrived within 5s — refusing to continue to the provider.',
+      color: '#b91c1c',
+    },
+    navigating: {
+      msg:
+        'grant stored in vault-origin sessionStorage — navigating to the provider…',
+      color: '#15803d',
+    },
+  };
+
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: 24 }}>
+      <h2 style={{ marginTop: 0 }}>Launcher (proposed vault oauth/launch)</h2>
+      <div
+        style={{
+          padding: '10px 14px',
+          borderRadius: 6,
+          color: '#fff',
+          background: text[status].color,
+        }}
+      >
+        <strong>{text[status].msg}</strong>
+      </div>
+      <p style={{ fontSize: 13, color: '#475569' }}>
+        run <code>{run}</code> · mode <code>{mode}</code> · origin{' '}
+        <code>{window.location.origin}</code> · served without COOP, so the
+        opener link is intact here by construction.
+      </p>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/storage-roundtrip/provider.html
+++ b/example/storage-roundtrip/provider.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>provider — COOP stand-in (severs the opener mid-chain)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./provider.tsx"></script>
+  </body>
+</html>

--- a/example/storage-roundtrip/provider.tsx
+++ b/example/storage-roundtrip/provider.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { ORIGINS, postReport, readMode, readRun, storageKey } from './shared';
+
+// Provider stand-in, served from [::1] — cross-origin to the launcher and the
+// callback (both localhost). In `?opener=severed` the Vite middleware serves
+// THIS page with `Cross-Origin-Opener-Policy: same-origin`, which swaps the
+// tab's browsing-context group and severs window.opener — the mid-chain
+// severance a real provider can cause and that the proposed design must
+// survive. After a short "consent" pause it navigates on to the callback,
+// like a provider redirecting to the OAuth redirect_uri.
+
+const mode = readMode();
+const run = readRun();
+const severed = mode === 'severed';
+const openerAlive = !!window.opener;
+
+// A different origin means a different sessionStorage bucket: the grant the
+// launcher stored on localhost must be invisible here. Read it to prove it.
+let grantVisibleHere = false;
+try {
+  grantVisibleHere = sessionStorage.getItem(storageKey(run)) !== null;
+} catch {
+  grantVisibleHere = false;
+}
+
+// Progress ping: proves the provider hop loaded (Safari, notably, cannot load
+// literal-IPv6 origins at all — see shared.ts).
+postReport({
+  run,
+  mode,
+  stage: 'provider',
+  ok: true,
+  reason: 'provider reached',
+  openerAlive,
+});
+
+window.setTimeout(() => {
+  window.location.replace(
+    `${ORIGINS.vault}/storage-roundtrip/callback.html?opener=${mode}&run=${run}`
+  );
+}, 1200);
+
+const App = () => (
+  <div style={{ fontFamily: 'system-ui', padding: 24 }}>
+    <h2 style={{ marginTop: 0 }}>Provider (consent stand-in)</h2>
+    <div
+      style={{
+        padding: '10px 14px',
+        borderRadius: 6,
+        color: '#fff',
+        background: severed ? '#b91c1c' : '#15803d',
+      }}
+    >
+      <strong>
+        served {severed ? 'WITH COOP: same-origin' : 'without COOP'} ·
+        window.opener is {openerAlive ? 'LIVE' : 'null'}
+      </strong>
+      <div style={{ marginTop: 6, fontSize: 13, opacity: 0.95 }}>
+        {severed
+          ? 'The browsing-context group just swapped — the opener channel is dead for the rest of this tab’s life. The experiment asks whether sessionStorage survives this.'
+          : 'No COOP anywhere — the opener survives the whole chain (today’s happy path).'}
+      </div>
+    </div>
+    <p style={{ fontSize: 13, color: '#475569' }}>
+      run <code>{run}</code> · origin <code>{window.location.origin}</code> ·
+      grant visible from this origin:{' '}
+      <strong>{grantVisibleHere ? 'YES (unexpected!)' : 'no'}</strong> — it
+      lives in another origin’s sessionStorage bucket, so the provider can’t
+      read it.
+    </p>
+    <p style={{ fontSize: 13, color: '#475569' }}>Redirecting to the callback…</p>
+  </div>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/storage-roundtrip/shared.ts
+++ b/example/storage-roundtrip/shared.ts
@@ -1,0 +1,107 @@
+// sessionStorage round-trip experiment — step 0 of the proposed OAuth-confirm
+// handoff redesign (see ../../thoughts/shared/research/2026-07-14-oauth-confirm-
+// iframe-context.md for the problem; ../opener-severed-confirm/ for the repro
+// of today's failure).
+//
+// The proposed design: the widget delivers a single-use "grant" into the OAuth
+// popup at OPEN time over the then-guaranteed window.opener link; the popup's
+// vault-origin launcher stores it in the tab's sessionStorage; after the
+// provider redirect chain the vault-origin callback reads it back and
+// self-confirms in-tab — no dependency on window.opener at callback time.
+//
+// The design's single unverified assumption, which this harness tests:
+//
+//   Does a tab's vault-origin sessionStorage survive the browsing-context-
+//   group swaps that COOP: same-origin pages cause mid-chain?
+//
+// Same three-loopback-origin trick as ../opener-severed-confirm/ — one Vite
+// dev server (`server.host: true`), three distinct origins:
+//
+//   host     (localhost)  top-level customer page stand-in
+//   widget   (127.0.0.1)  cross-origin iframe, runs the experiment
+//   launch   (localhost)  popup page 1 — vault-origin launcher, NO COOP
+//   provider ([::1])      popup page 2 — COOP: same-origin in severed mode
+//   callback (localhost)  popup page 3 — vault origin again, reads the grant
+//                         (also COOP-served in severed mode: we don't control
+//                         the real callback's effective policy either)
+
+const PORT =
+  typeof window !== 'undefined' && window.location.port
+    ? window.location.port
+    : '1234';
+
+// Safari cannot load literal-IPv6 URLs (http://[::1]:…) — a long-standing
+// WebKit/Safari networking limitation that Chrome, Firefox and DuckDuckGo
+// handle fine. On Safari-like browsers the provider falls back to 127.0.0.1.
+// That makes the provider share the WIDGET's origin, which is cosmetically
+// less realistic but mechanically irrelevant to the experiment: the tested
+// storage bucket is the popup tab's localhost (vault) one, and 127.0.0.1 is
+// still cross-origin to it, so the COOP context-group swap still happens.
+const isSafariLike =
+  typeof navigator !== 'undefined' &&
+  /safari/i.test(navigator.userAgent) &&
+  !/chrome|chromium|crios|firefox|fxios|edg/i.test(navigator.userAgent);
+
+export const ORIGINS = {
+  host: `http://localhost:${PORT}`,
+  widget: `http://127.0.0.1:${PORT}`,
+  vault: `http://localhost:${PORT}`,
+  provider: isSafariLike
+    ? `http://127.0.0.1:${PORT}`
+    : `http://[::1]:${PORT}`,
+};
+
+export type OpenerMode = 'intact' | 'severed';
+
+export function readMode(): OpenerMode {
+  const m = new URLSearchParams(window.location.search).get('opener');
+  return m === 'severed' ? 'severed' : 'intact';
+}
+
+export const READY_MESSAGE = 'storage-roundtrip-ready';
+export const GRANT_MESSAGE = 'storage-roundtrip-grant';
+
+// Per-run sessionStorage key on the vault-origin stand-in (localhost).
+export const storageKey = (run: string) => `storage-roundtrip:${run}`;
+
+// Correlation id for one run — NOT a secret. It mirrors production, where the
+// widget learns the outcome by polling its own connection state at unify; here
+// it polls the dev server's report endpoint by run id. The grant is the secret
+// and never appears in any URL.
+export function readRun(): string {
+  return new URLSearchParams(window.location.search).get('run') ?? 'no-run';
+}
+
+export function randomId(): string {
+  const c = typeof crypto !== 'undefined' ? (crypto as any) : undefined;
+  if (c?.randomUUID) return c.randomUUID();
+  return `${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+// Report endpoint served by the Vite dev middleware (storageRoundtripPlugin in
+// ../vite.config.ts). Every origin hits the same server process, so relative
+// fetches are same-origin from both the widget (127.0.0.1) and the callback
+// (localhost), and the in-memory report store is shared.
+export const REPORT_API = '/storage-roundtrip/api';
+
+export interface RunReport {
+  run: string;
+  mode: OpenerMode;
+  // 'launch' and 'provider' with ok: true are progress pings so a stalled
+  // chain pinpoints its last completed hop; 'callback' is the final verdict.
+  stage: 'launch' | 'provider' | 'callback';
+  ok: boolean;
+  reason?: string;
+  grantSurvived?: boolean;
+  grant?: string | null;
+  openerAlive?: boolean;
+  storageReadable?: boolean;
+  userAgent?: string;
+}
+
+export const postReport = (report: RunReport) =>
+  fetch(`${REPORT_API}/report`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(report),
+  }).catch(() => undefined);

--- a/example/storage-roundtrip/widget.html
+++ b/example/storage-roundtrip/widget.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>storage round-trip experiment — widget</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./widget.tsx"></script>
+  </body>
+</html>

--- a/example/storage-roundtrip/widget.tsx
+++ b/example/storage-roundtrip/widget.tsx
@@ -1,0 +1,227 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {
+  GRANT_MESSAGE,
+  ORIGINS,
+  READY_MESSAGE,
+  REPORT_API,
+  RunReport,
+  randomId,
+  readMode,
+} from './shared';
+
+// The embedded-widget stand-in (127.0.0.1, cross-origin iframe). Plays
+// vault-core's role in the proposed design:
+//
+//   1. open the vault-origin launcher popup SYNCHRONOUSLY on click (popup
+//      blockers require the user gesture)
+//   2. on the launcher's ready ping, deliver a freshly minted grant via
+//      postMessage with an EXPLICIT targetOrigin (the vault origin it just
+//      opened — derived from configuration, not an inbound-origin allowlist)
+//   3. learn the outcome by polling the server (here: the dev middleware's
+//      report endpoint; in production: the connection state at unify) — no
+//      secret ever travels popup → widget
+
+const { useEffect, useRef, useState } = React;
+
+const mode = readMode();
+
+type State =
+  | { phase: 'idle' }
+  | { phase: 'pending'; note: string }
+  | { phase: 'done'; report: RunReport }
+  | { phase: 'timeout'; lastProgress: string };
+
+const App = () => {
+  const [state, setState] = useState<State>({ phase: 'idle' });
+  const runRef = useRef<string | null>(null);
+  const grantRef = useRef<string>('');
+  const pollRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      const data = event.data as any;
+      if (
+        data?.type !== READY_MESSAGE ||
+        data.run !== runRef.current ||
+        !event.source
+      ) {
+        return;
+      }
+      // The grant crosses the live opener link exactly once, aimed at the
+      // vault origin only. This postMessage is the whole security story: a
+      // handed-out URL cannot carry it.
+      (event.source as Window).postMessage(
+        { type: GRANT_MESSAGE, run: data.run, grant: grantRef.current },
+        ORIGINS.vault
+      );
+      setState({
+        phase: 'pending',
+        note:
+          'handshake complete — grant delivered over the live opener link; waiting for the callback report…',
+      });
+    };
+    window.addEventListener('message', onMessage);
+    return () => {
+      window.removeEventListener('message', onMessage);
+      if (pollRef.current) window.clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const runExperiment = () => {
+    const run = randomId();
+    runRef.current = run;
+    grantRef.current = `grant-${randomId()}`;
+    setState({
+      phase: 'pending',
+      note: 'popup opened — waiting for the launcher’s ready ping…',
+    });
+    // Synchronous open inside the click handler; the run id in the URL is a
+    // non-secret correlation id.
+    window.open(
+      `${ORIGINS.vault}/storage-roundtrip/launch.html?opener=${mode}&run=${run}`,
+      'storage-roundtrip',
+      'width=560,height=680'
+    );
+
+    if (pollRef.current) window.clearInterval(pollRef.current);
+    const startedAt = Date.now();
+    let lastProgress = 'no report received at all';
+    pollRef.current = window.setInterval(async () => {
+      try {
+        const res = await fetch(`${REPORT_API}/result?run=${run}`);
+        if (res.ok) {
+          const report = (await res.json()) as RunReport;
+          // 'launch'/'provider' with ok are progress pings; only a callback
+          // report or an explicit refusal ends the run.
+          const final =
+            report.stage === 'callback' ||
+            (report.stage === 'launch' && !report.ok);
+          if (final) {
+            window.clearInterval(pollRef.current);
+            setState({ phase: 'done', report });
+            return;
+          }
+          lastProgress = `last completed hop: ${report.stage} (${report.reason})`;
+          setState({
+            phase: 'pending',
+            note: `popup progress — ${lastProgress}; waiting for the callback report…`,
+          });
+        }
+      } catch {
+        // dev server hiccup — keep polling until the deadline
+      }
+      if (Date.now() - startedAt > 30000) {
+        window.clearInterval(pollRef.current);
+        setState(s =>
+          s.phase === 'done' ? s : { phase: 'timeout', lastProgress }
+        );
+      }
+    }, 500);
+  };
+
+  const renderReport = (report: RunReport) => {
+    if (report.stage === 'launch') {
+      return (
+        <div style={{ color: '#b91c1c' }}>
+          <strong>Launcher refused: {report.reason}</strong> — the flow never
+          reached the provider. {report.reason === 'no-opener'
+            ? 'The opener was dead at open time (the one COOP case the design converts from silent strand to loud failure).'
+            : ''}
+        </div>
+      );
+    }
+    if (report.grantSurvived) {
+      const openerDead = !report.openerAlive;
+      return (
+        <div style={{ color: '#15803d' }}>
+          <strong>
+            {mode === 'severed' && openerDead
+              ? 'GO ✅ — grant survived the COOP swaps; opener was dead.'
+              : 'Grant survived ✅.'}
+          </strong>{' '}
+          The callback self-confirmed in-tab
+          {openerDead
+            ? ' where today’s opener channel would have dropped the token.'
+            : '; the opener channel was also alive (both channels work in this mode).'}
+        </div>
+      );
+    }
+    return (
+      <div style={{ color: '#b91c1c' }}>
+        <strong>NO-GO ❌ — the grant did not survive to the callback.</strong>{' '}
+        {report.storageReadable === false
+          ? 'sessionStorage was unreadable at the callback.'
+          : 'sessionStorage was readable but the grant was gone.'}{' '}
+        Design assumption falsified on: <code>{report.userAgent}</code>
+      </div>
+    );
+  };
+
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: 16 }}>
+      <div
+        style={{
+          padding: '8px 12px',
+          color: '#fff',
+          borderRadius: 6,
+          marginBottom: 16,
+          background: '#0f172a',
+          fontSize: 13,
+        }}
+      >
+        <strong>widget</strong> · <code>{ORIGINS.widget}</code> (cross-origin
+        iframe) · popup chain mode <strong>{mode}</strong> · provider origin{' '}
+        <code>{ORIGINS.provider}</code>
+        {ORIGINS.provider.includes('127.0.0.1')
+          ? ' (Safari fallback — WebKit can’t load literal-IPv6 URLs)'
+          : ''}
+      </div>
+
+      <div
+        style={{
+          border: '1px solid #e2e8f0',
+          borderRadius: 8,
+          padding: 16,
+        }}
+      >
+        <div style={{ fontWeight: 600, marginBottom: 4 }}>
+          sessionStorage round-trip (proposed confirm-handoff fix, step 0)
+        </div>
+        <p style={{ margin: '0 0 12px', fontSize: 13, color: '#475569' }}>
+          Opens the vault-origin launcher popup, delivers a grant over the live
+          opener link at open time, then the popup navigates{' '}
+          <code>launcher → provider{mode === 'severed' ? ' (COOP)' : ''} →
+          callback</code> in one tab. The callback reads the grant from
+          sessionStorage and reports here via the dev server — the production
+          analog of the widget polling unify.
+        </p>
+        <button
+          onClick={runExperiment}
+          style={{ padding: '8px 14px', cursor: 'pointer' }}
+        >
+          Run experiment
+        </button>
+        <div style={{ marginTop: 12, fontSize: 13 }}>
+          {state.phase === 'idle' && (
+            <span style={{ color: '#475569' }}>not run yet</span>
+          )}
+          {state.phase === 'pending' && (
+            <span style={{ color: '#b45309' }}>{state.note}</span>
+          )}
+          {state.phase === 'timeout' && (
+            <span style={{ color: '#b91c1c' }}>
+              No callback report within 30s ({state.lastProgress}). Popup
+              blocked, closed early — or the next hop's origin doesn't load in
+              this browser (check what the popup shows). Allow popups for this
+              host and re-run.
+            </span>
+          )}
+          {state.phase === 'done' && renderReport(state.report)}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
@@ -10,13 +10,115 @@ const pages = {
   index: path.resolve(__dirname, 'index.html'),
   iframe: path.resolve(__dirname, 'iframe-test/iframe.html'),
   vault: path.resolve(__dirname, 'iframe-test/vault.html'),
+  // opener-severed confirm repro (OCTA): real <Vault> widget nested in genuine
+  // cross-origin iframes (localhost → 127.0.0.1 → [::1]) against real Unify,
+  // plus a probe popup (probe.html) that models vault's oauth/callback.
+  openerOuter: path.resolve(__dirname, 'opener-severed-confirm/outer.html'),
+  openerMiddle: path.resolve(__dirname, 'opener-severed-confirm/middle.html'),
+  openerWidget: path.resolve(__dirname, 'opener-severed-confirm/widget.html'),
+  openerProbe: path.resolve(__dirname, 'opener-severed-confirm/probe.html'),
+  // sessionStorage round-trip experiment (storage-roundtrip/): step 0 of the
+  // proposed confirm-handoff fix — does a tab's vault-origin sessionStorage
+  // survive COOP browsing-context-group swaps mid-navigation-chain?
+  storageHost: path.resolve(__dirname, 'storage-roundtrip/host.html'),
+  storageWidget: path.resolve(__dirname, 'storage-roundtrip/widget.html'),
+  storageLaunch: path.resolve(__dirname, 'storage-roundtrip/launch.html'),
+  storageProvider: path.resolve(__dirname, 'storage-roundtrip/provider.html'),
+  storageCallback: path.resolve(__dirname, 'storage-roundtrip/callback.html'),
 };
+
+// Deterministically reproduce the OCTA opener severance with a REAL header
+// instead of monkey-patching window.open. COOP is ignored on iframe documents
+// and we don't control the real vault callback's headers, so the lever that
+// genuinely applies is `Cross-Origin-Opener-Policy: same-origin` on the popup's
+// OWN landing page (probe.html — our stand-in for vault's oauth/callback, which
+// IS top-level so COOP takes effect). When that page is cross-origin to the
+// widget that opened it, the browser swaps browsing-context groups and the
+// popup's `window.opener` becomes null — exactly the production condition.
+//
+// COOP on the top-level host (outer.html) would NOT help: a popup's initial
+// document inherits the top-level COOP only when the creator document is
+// same-origin with its top level, and the widget iframe is cross-origin to
+// outer — so the host's header never reaches popups the widget opens. Only
+// pages inside the popup's own navigation chain (provider, vault callback)
+// can sever it.
+function openerCoopPlugin(): Plugin {
+  const severed = (url: string) =>
+    /[?&]opener=severed/.test(url) &&
+    /\/opener-severed-confirm\/probe\.html/.test(url);
+  return {
+    name: 'opener-severed-coop',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url && severed(req.url)) {
+          res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        }
+        next();
+      });
+    },
+  };
+}
+
+// storage-roundtrip experiment support:
+//  - COOP: same-origin on the popup chain's provider AND callback pages in
+//    severed mode (the launcher stays COOP-free by design — it's the page
+//    "we" control), forcing browsing-context-group swaps mid-chain.
+//  - a tiny in-memory report API: the popup's final page POSTs its verdict,
+//    the widget polls for it — the dev-server analog of the widget polling
+//    unify for the connection state, since no browser channel reaches a
+//    cross-origin nested iframe from a popup (that impossibility is the whole
+//    point of the experiment).
+function storageRoundtripPlugin(): Plugin {
+  const coop = (url: string) =>
+    /[?&]opener=severed/.test(url) &&
+    /\/storage-roundtrip\/(provider|callback)\.html/.test(url);
+  const reports = new Map<string, unknown>();
+  return {
+    name: 'storage-roundtrip',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url ?? '';
+        if (url.startsWith('/storage-roundtrip/api/report') && req.method === 'POST') {
+          let body = '';
+          req.on('data', chunk => (body += chunk));
+          req.on('end', () => {
+            try {
+              const data = JSON.parse(body);
+              if (data?.run) reports.set(String(data.run), data);
+            } catch {
+              // ignore malformed reports
+            }
+            res.statusCode = 204;
+            res.end();
+          });
+          return;
+        }
+        if (url.startsWith('/storage-roundtrip/api/result')) {
+          const run = new URLSearchParams(url.split('?')[1] ?? '').get('run');
+          const report = run ? reports.get(run) : undefined;
+          res.setHeader('Content-Type', 'application/json');
+          if (report) {
+            res.end(JSON.stringify(report));
+          } else {
+            res.statusCode = 404;
+            res.end('{}');
+          }
+          return;
+        }
+        if (coop(url)) {
+          res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        }
+        next();
+      });
+    },
+  };
+}
 
 // Force a single React copy across the example AND the in-tree vault-core source.
 // Without this, Vite finds nested React copies in the parent's node_modules and
 // the React tree fails with "Invalid hook call".
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), openerCoopPlugin(), storageRoundtripPlugin()],
   resolve: {
     dedupe: ['react', 'react-dom'],
     alias: {
@@ -36,5 +138,9 @@ export default defineConfig({
   server: {
     port: 1234,
     open: false,
+    // Bind all loopback addresses so the opener-severed harness can nest the
+    // widget across genuinely different origins on one server: localhost,
+    // 127.0.0.1 and [::1] are three distinct origins that all hit this server.
+    host: true,
   },
 });

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -25,6 +25,17 @@ const pages = {
   storageLaunch: path.resolve(__dirname, 'storage-roundtrip/launch.html'),
   storageProvider: path.resolve(__dirname, 'storage-roundtrip/provider.html'),
   storageCallback: path.resolve(__dirname, 'storage-roundtrip/callback.html'),
+  // grant-handoff end-to-end harness (grant-handoff/): the REAL <Vault> on the
+  // NEW grant-handoff code path against REAL local unify (https://localhost:3050)
+  // with a REAL OAuth round-trip. The harness only serves its OWN vault-side
+  // oauth/launch + oauth/callback stand-ins (so it can inject COOP on the
+  // callback); everything unify does is real. Proves severed mode still reaches
+  // state `callable`.
+  grantHandoffOuter: path.resolve(__dirname, 'grant-handoff/outer.html'),
+  grantHandoffMiddle: path.resolve(__dirname, 'grant-handoff/middle.html'),
+  grantHandoffWidget: path.resolve(__dirname, 'grant-handoff/widget.html'),
+  grantHandoffLaunch: path.resolve(__dirname, 'grant-handoff/launch.html'),
+  grantHandoffCallback: path.resolve(__dirname, 'grant-handoff/callback.html'),
 };
 
 // Deterministically reproduce the OCTA opener severance with a REAL header
@@ -78,9 +89,12 @@ function storageRoundtripPlugin(): Plugin {
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
         const url = req.url ?? '';
-        if (url.startsWith('/storage-roundtrip/api/report') && req.method === 'POST') {
+        if (
+          url.startsWith('/storage-roundtrip/api/report') &&
+          req.method === 'POST'
+        ) {
           let body = '';
-          req.on('data', chunk => (body += chunk));
+          req.on('data', (chunk) => (body += chunk));
           req.on('end', () => {
             try {
               const data = JSON.parse(body);
@@ -114,11 +128,67 @@ function storageRoundtripPlugin(): Plugin {
   };
 }
 
+// grant-handoff end-to-end harness support (grant-handoff/). This harness drives
+// the REAL <Vault> against REAL local unify (https://localhost:3050) with a REAL
+// OAuth round-trip — there is NO unify stub and NO CORS shim here (unify serves
+// its own endpoints and its own CORS). The dev server's ONLY jobs are:
+//   1. Internal rewrites (keep the query string) so deriveLaunchUrl's hard-coded
+//      /oauth/launch and unify's redirect to /oauth/callback resolve to our own
+//      COOP-controllable stand-in pages.
+//   2. COOP lever: Cross-Origin-Opener-Policy: same-origin on the CALLBACK ONLY
+//      in severed mode (NEVER the launch page) — this is what severs the popup's
+//      window.opener, reproducing the OCTA condition. Real unify redirects back
+//      to /oauth/callback without our ?opener param, so severed mode is read from
+//      the `gh_opener` cookie the outer host set on the localhost origin (with a
+//      query-param fallback for direct hits).
+function grantHandoffPlugin(): Plugin {
+  const isSevered = (query: URLSearchParams, cookie: string): boolean => {
+    if (query.get('opener') === 'severed') return true;
+    return /(?:^|;\s*)gh_opener=severed(?:;|$)/.test(cookie);
+  };
+
+  return {
+    name: 'grant-handoff',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const rawUrl = req.url ?? '';
+        const [pathOnly, search = ''] = rawUrl.split('?');
+        const query = new URLSearchParams(search);
+
+        // 1. Internal rewrites (keep the query string) so /oauth/launch and
+        //    /oauth/callback resolve to our real stand-in pages.
+        if (pathOnly === '/oauth/launch') {
+          req.url = `/grant-handoff/launch.html${search ? `?${search}` : ''}`;
+        } else if (pathOnly === '/oauth/callback') {
+          req.url = `/grant-handoff/callback.html${search ? `?${search}` : ''}`;
+        }
+
+        // 2. COOP lever in severed mode — the CALLBACK ONLY, never the launch
+        //    page. The launch page must keep window.opener intact by
+        //    construction; severance happens here, on the final callback.
+        const coopTarget = /\/grant-handoff\/callback\.html/.test(
+          req.url ?? ''
+        );
+        if (coopTarget && isSevered(query, req.headers.cookie ?? '')) {
+          res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        }
+
+        next();
+      });
+    },
+  };
+}
+
 // Force a single React copy across the example AND the in-tree vault-core source.
 // Without this, Vite finds nested React copies in the parent's node_modules and
 // the React tree fails with "Invalid hook call".
 export default defineConfig({
-  plugins: [react(), openerCoopPlugin(), storageRoundtripPlugin()],
+  plugins: [
+    react(),
+    openerCoopPlugin(),
+    storageRoundtripPlugin(),
+    grantHandoffPlugin(),
+  ],
   resolve: {
     dedupe: ['react', 'react-dom'],
     alias: {

--- a/src/components/AuthorizeButton.tsx
+++ b/src/components/AuthorizeButton.tsx
@@ -8,10 +8,8 @@ import { Connection } from '../types/Connection';
 import { OAuthPostMessage } from '../types/OAuthCsrf';
 import { callConfirmEndpoint, generateNonce } from '../utils/oauthCsrf';
 import {
-  deriveLaunchUrl,
-  mintGrant,
-  pollForCallable,
-  runLaunchHandshake,
+  openGrantHandoffPopup,
+  watchPopupCloseAndPoll,
 } from '../utils/oauthGrantHandoff';
 import { useConnections } from '../utils/useConnections';
 import { useSession } from '../utils/useSession';
@@ -104,19 +102,24 @@ const AuthorizeButton = ({
       url.searchParams.append('nonce', nonce);
 
       let completed = false;
-      let timer: ReturnType<typeof setInterval> | undefined;
-      let graceTimeout: ReturnType<typeof setTimeout> | undefined;
-      let cancelCallablePoll: (() => void) | undefined;
+      let cancelCloseWatch: (() => void) | undefined;
 
       const cleanup = () => {
         completed = true;
         window.removeEventListener('message', handler);
-        if (timer) clearInterval(timer);
-        if (graceTimeout) clearTimeout(graceTimeout);
-        cancelCallablePoll?.();
-        cancelCallablePoll = undefined;
+        cancelCloseWatch?.();
+        cancelCloseWatch = undefined;
         cleanupRef.current = null;
         setIsLoading(false);
+      };
+
+      const refreshConnection = () => {
+        mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
+          (result) => {
+            onConnectionChange?.(result?.data);
+          }
+        );
+        mutate('/vault/connections');
       };
 
       const handler = async (event: MessageEvent) => {
@@ -161,88 +164,43 @@ const AuthorizeButton = ({
           return;
         }
 
-        mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
-          (result) => {
-            onConnectionChange?.(result?.data);
-          }
-        );
-        mutate('/vault/connections');
+        refreshConnection();
         cleanup();
       };
 
       window.addEventListener('message', handler);
       cleanupRef.current = cleanup;
 
-      // Open the popup on the launch URL synchronously (popup blockers) and
-      // mint the grant in parallel — the grant is never awaited before open
-      // and never carried in a URL.
-      const { launchUrl, launchOrigin } = deriveLaunchUrl(
-        { redirect_uri },
-        serviceId
-      );
-
-      const child = window.open(
-        launchUrl,
-        '_blank',
-        'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0'
-      );
-
-      const grantPromise = mintGrant({
+      const child = openGrantHandoffPopup({
+        session: { redirect_uri },
         unifiedApi,
         serviceId,
         connectionsUrl: connectionsUrl ?? '',
         headers,
+        legacyAuthorizeUrl: url.href,
       });
 
-      if (child) {
-        // Fire-and-forget: the handshake removes its own listener and timer
-        // once it resolves ('handoff' or 'legacy' fallback navigation).
-        runLaunchHandshake({
-          child,
-          launchOrigin,
-          legacyAuthorizeUrl: url.href,
-          grantPromise,
-        });
-      }
-
-      timer = setInterval(() => {
-        if (child?.closed) {
-          if (timer) clearInterval(timer);
-          timer = undefined;
-          graceTimeout = setTimeout(() => {
-            if (completed) return;
-            // The popup closed without a definitive oauth_complete /
-            // oauth_error message — poll the connection state instead of
-            // blindly reporting success.
-            const { promise, cancel } = pollForCallable({
-              detailUrl: `${connectionsUrl}/${unifiedApi}/${serviceId}`,
-              headers,
+      cancelCloseWatch = watchPopupCloseAndPoll({
+        child,
+        detailUrl: `${connectionsUrl}/${unifiedApi}/${serviceId}`,
+        headers,
+        isCompleted: () => completed,
+        onOutcome: (outcome) => {
+          if (outcome === 'callable') {
+            refreshConnection();
+          } else {
+            addToast({
+              title: t('Authorization was not completed'),
+              description: t(
+                'The authorization window was closed before the connection became ready. Please try again.'
+              ),
+              type: 'error',
+              autoClose: true,
             });
-            cancelCallablePoll = cancel;
-            promise.then((outcome) => {
-              cancelCallablePoll = undefined;
-              if (outcome === 'callable') {
-                mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
-                  (result) => {
-                    onConnectionChange?.(result?.data);
-                  }
-                );
-                mutate('/vault/connections');
-              } else {
-                addToast({
-                  title: t('Authorization was not completed'),
-                  description: t(
-                    'The authorization window was closed before the connection became ready. Please try again.'
-                  ),
-                  type: 'error',
-                  autoClose: true,
-                });
-              }
-              cleanup();
-            });
-          }, 1000);
-        }
-      }, 500);
+          }
+          cleanup();
+        },
+      }).cancel;
     }
   };
 

--- a/src/components/AuthorizeButton.tsx
+++ b/src/components/AuthorizeButton.tsx
@@ -7,6 +7,12 @@ import { REDIRECT_URL } from '../constants/urls';
 import { Connection } from '../types/Connection';
 import { OAuthPostMessage } from '../types/OAuthCsrf';
 import { callConfirmEndpoint, generateNonce } from '../utils/oauthCsrf';
+import {
+  deriveLaunchUrl,
+  mintGrant,
+  pollForCallable,
+  runLaunchHandshake,
+} from '../utils/oauthGrantHandoff';
 import { useConnections } from '../utils/useConnections';
 import { useSession } from '../utils/useSession';
 
@@ -44,15 +50,6 @@ const AuthorizeButton = ({
       cleanupRef.current?.();
     };
   }, []);
-
-  const handleChildWindowClose = () => {
-    mutate(
-      `${connectionsUrl}/${connection?.unified_api}/${connection?.service_id}`
-    ).then((result) => {
-      onConnectionChange?.(result.data);
-    });
-    setIsLoading(false);
-  };
 
   const authorizeConnection = async () => {
     setIsLoading(true);
@@ -109,12 +106,15 @@ const AuthorizeButton = ({
       let completed = false;
       let timer: ReturnType<typeof setInterval> | undefined;
       let graceTimeout: ReturnType<typeof setTimeout> | undefined;
+      let cancelCallablePoll: (() => void) | undefined;
 
       const cleanup = () => {
         completed = true;
         window.removeEventListener('message', handler);
         if (timer) clearInterval(timer);
         if (graceTimeout) clearTimeout(graceTimeout);
+        cancelCallablePoll?.();
+        cancelCallablePoll = undefined;
         cleanupRef.current = null;
         setIsLoading(false);
       };
@@ -173,21 +173,73 @@ const AuthorizeButton = ({
       window.addEventListener('message', handler);
       cleanupRef.current = cleanup;
 
+      // Open the popup on the launch URL synchronously (popup blockers) and
+      // mint the grant in parallel — the grant is never awaited before open
+      // and never carried in a URL.
+      const { launchUrl, launchOrigin } = deriveLaunchUrl(
+        { redirect_uri },
+        serviceId
+      );
+
       const child = window.open(
-        url.href,
+        launchUrl,
         '_blank',
         'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0'
       );
+
+      const grantPromise = mintGrant({
+        unifiedApi,
+        serviceId,
+        connectionsUrl: connectionsUrl ?? '',
+        headers,
+      });
+
+      if (child) {
+        // Fire-and-forget: the handshake removes its own listener and timer
+        // once it resolves ('handoff' or 'legacy' fallback navigation).
+        runLaunchHandshake({
+          child,
+          launchOrigin,
+          legacyAuthorizeUrl: url.href,
+          grantPromise,
+        });
+      }
 
       timer = setInterval(() => {
         if (child?.closed) {
           if (timer) clearInterval(timer);
           timer = undefined;
           graceTimeout = setTimeout(() => {
-            if (!completed) {
-              handleChildWindowClose();
+            if (completed) return;
+            // The popup closed without a definitive oauth_complete /
+            // oauth_error message — poll the connection state instead of
+            // blindly reporting success.
+            const { promise, cancel } = pollForCallable({
+              detailUrl: `${connectionsUrl}/${unifiedApi}/${serviceId}`,
+              headers,
+            });
+            cancelCallablePoll = cancel;
+            promise.then((outcome) => {
+              cancelCallablePoll = undefined;
+              if (outcome === 'callable') {
+                mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
+                  (result) => {
+                    onConnectionChange?.(result?.data);
+                  }
+                );
+                mutate('/vault/connections');
+              } else {
+                addToast({
+                  title: t('Authorization was not completed'),
+                  description: t(
+                    'The authorization window was closed before the connection became ready. Please try again.'
+                  ),
+                  type: 'error',
+                  autoClose: true,
+                });
+              }
               cleanup();
-            }
+            });
           }, 1000);
         }
       }, 500);

--- a/src/components/ButtonLayoutMenu.tsx
+++ b/src/components/ButtonLayoutMenu.tsx
@@ -102,7 +102,10 @@ const ButtonLayoutMenu: React.FC<Props> = ({
             }`
           );
           url.searchParams.append('nonce', nonce);
-          await handleRedirect(url.href, onConnectionChange);
+          await handleRedirect(url.href, onConnectionChange, {
+            unifiedApi: connection.unified_api,
+            serviceId: connection.service_id,
+          });
         },
         variant: 'primary',
         customComponent: (
@@ -290,7 +293,10 @@ const ButtonLayoutMenu: React.FC<Props> = ({
             }`
           );
           url.searchParams.append('nonce', nonce);
-          await handleRedirect(url.href, onConnectionChange);
+          await handleRedirect(url.href, onConnectionChange, {
+            unifiedApi: connection.unified_api,
+            serviceId: connection.service_id,
+          });
         },
         variant: 'outline',
       });

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -67,6 +67,8 @@ const TopBar = ({
       authorize_url,
       revoke_url,
       custom_mappings,
+      unified_api,
+      service_id,
     } = selectedConnection;
     const authorizeUrl = `${authorize_url}&redirect_uri=${
       session?.redirect_uri ?? REDIRECT_URL
@@ -240,7 +242,10 @@ const TopBar = ({
           const nonce = generateNonce();
           const url = new URL(authorizeUrl);
           url.searchParams.append('nonce', nonce);
-          handleRedirect(url.href, onConnectionChange);
+          handleRedirect(url.href, onConnectionChange, {
+            unifiedApi: unified_api,
+            serviceId: service_id,
+          });
         },
       });
     }

--- a/src/components/Vault.tsx
+++ b/src/components/Vault.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement, forwardRef, useEffect, useState } from 'react';
 import { ToastProvider } from '@apideck/components';
 import jwtDecode from 'jwt-decode';
 import { useTranslation } from 'react-i18next';
+import { SWRConfig } from 'swr';
 import { BASE_URL } from '../constants/urls';
 import { Connection } from '../types/Connection';
 import { ConnectionViewType } from '../types/ConnectionViewType';
@@ -188,34 +189,38 @@ export const Vault = forwardRef<HTMLElement, Props>(function Vault(
           showAttribution={showAttribution}
           applicationId={session?.application_id}
         >
-          <ToastProvider>
-            <ConnectionsProvider
-              appId={session?.application_id as string}
-              consumerId={session?.consumer_id as string}
-              token={jwt as string}
-              isOpen={isOpen}
-              onClose={onCloseModal}
-              onConnectionChange={onConnectionChange}
-              onConnectionDelete={onConnectionDelete}
-              unifiedApi={unifiedApi}
-              serviceId={serviceId}
-              unifyBaseUrl={unifyBaseUrl}
-            >
-              <SessionProvider session={session}>
-                <ModalContent
-                  onClose={onCloseModal}
-                  onConnectionChange={onConnectionChange}
-                  consumer={
-                    showConsumer ? session?.consumer_metadata : undefined
-                  }
-                  initialView={initialView}
-                  showLanguageSwitch={showLanguageSwitch}
-                  showButtonLayout={showButtonLayout}
-                  autoStartAuthorization={autoStartAuthorization}
-                />
-              </SessionProvider>
-            </ConnectionsProvider>
-          </ToastProvider>
+          {/* A fresh SWR cache per Vault mount: connection state must never
+              leak between mounts (or between consumers embedding Vault). */}
+          <SWRConfig value={{ provider: () => new Map() }}>
+            <ToastProvider>
+              <ConnectionsProvider
+                appId={session?.application_id as string}
+                consumerId={session?.consumer_id as string}
+                token={jwt as string}
+                isOpen={isOpen}
+                onClose={onCloseModal}
+                onConnectionChange={onConnectionChange}
+                onConnectionDelete={onConnectionDelete}
+                unifiedApi={unifiedApi}
+                serviceId={serviceId}
+                unifyBaseUrl={unifyBaseUrl}
+              >
+                <SessionProvider session={session}>
+                  <ModalContent
+                    onClose={onCloseModal}
+                    onConnectionChange={onConnectionChange}
+                    consumer={
+                      showConsumer ? session?.consumer_metadata : undefined
+                    }
+                    initialView={initialView}
+                    showLanguageSwitch={showLanguageSwitch}
+                    showButtonLayout={showButtonLayout}
+                    autoStartAuthorization={autoStartAuthorization}
+                  />
+                </SessionProvider>
+              </ConnectionsProvider>
+            </ToastProvider>
+          </SWRConfig>
         </Modal>
       ) : null}
     </div>

--- a/src/constants/oauthGrantHandoff.ts
+++ b/src/constants/oauthGrantHandoff.ts
@@ -1,0 +1,12 @@
+// How long to wait for the popup's `oauth_launch_ready` message before
+// falling back to the legacy flow — covers vault deployments that don't
+// serve the launch page yet.
+export const LAUNCH_READY_TIMEOUT_MS = 3000;
+
+// How often to poll the connection state for `callable` after the popup
+// closes.
+export const CALLABLE_POLL_INTERVAL_MS = 1000;
+
+// Total time budget for the `callable` poll before giving up and reporting
+// a timeout.
+export const CALLABLE_POLL_BUDGET_MS = 15000;

--- a/src/constants/oauthGrantHandoff.ts
+++ b/src/constants/oauthGrantHandoff.ts
@@ -10,3 +10,15 @@ export const CALLABLE_POLL_INTERVAL_MS = 1000;
 // Total time budget for the `callable` poll before giving up and reporting
 // a timeout.
 export const CALLABLE_POLL_BUDGET_MS = 15000;
+
+// How often to check whether the OAuth popup has been closed.
+export const POPUP_CLOSE_CHECK_INTERVAL_MS = 500;
+
+// Grace period after the popup closes before treating the flow as abandoned —
+// gives an in-flight `oauth_complete` / `oauth_error` message time to arrive
+// and settle the flow first.
+export const POPUP_CLOSE_GRACE_MS = 1000;
+
+// Standard window features for the OAuth popups (authorize and revoke).
+export const OAUTH_POPUP_FEATURES =
+  'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0';

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,2 +1,3 @@
 export const REDIRECT_URL = 'https://vault.apideck.com/oauth/callback';
 export const BASE_URL = `https://unify.apideck.com`;
+export const OAUTH_LAUNCH_PATH = '/oauth/launch';

--- a/src/types/OAuthGrantHandoff.ts
+++ b/src/types/OAuthGrantHandoff.ts
@@ -1,0 +1,35 @@
+/**
+ * Wire contract for the OAuth grant handoff flow — the vault-core side of the
+ * vault `oauth/launch` contract. The grant is single-use, session-bound, and
+ * never carried in a URL; it is handed to the popup exclusively via
+ * postMessage with an explicit targetOrigin.
+ */
+
+// Popup → widget: the launch page has loaded and is ready to receive the grant.
+export interface LaunchReadyMessage {
+  type: 'oauth_launch_ready';
+}
+
+// Widget → popup: hand over the grant and the authorize URL to continue with.
+// Must be posted with an explicit `targetOrigin`, never `'*'`.
+export interface LaunchStartMessage {
+  type: 'oauth_launch_start';
+  grant: string;
+  authorizeUrl: string;
+}
+
+export interface GrantResponse {
+  status_code: number;
+  status: string;
+  data: {
+    grant: string;
+    expires_in: number;
+  };
+}
+
+// Result of the launch handshake: the popup answered with `oauth_launch_ready`
+// (handoff) or the timeout elapsed and we fall back to the legacy flow.
+export type HandshakeOutcome = 'handoff' | 'legacy';
+
+// Result of polling for connection state `callable` after the popup closes.
+export type PollOutcome = 'callable' | 'timeout';

--- a/src/utils/connectionActions.ts
+++ b/src/utils/connectionActions.ts
@@ -6,12 +6,12 @@ import { Connection } from '../types/Connection';
 import { ConnectionViewType } from '../types/ConnectionViewType';
 import { OAuthPostMessage } from '../types/OAuthCsrf';
 import { SessionSettings, VaultAction } from '../types/Session';
+import { OAUTH_POPUP_FEATURES } from '../constants/oauthGrantHandoff';
 import { callConfirmEndpoint } from './oauthCsrf';
 import {
-  deriveLaunchUrl,
-  mintGrant,
-  pollForCallable,
-  runLaunchHandshake,
+  openGrantHandoffPopup,
+  watchPopupClose,
+  watchPopupCloseAndPoll,
 } from './oauthGrantHandoff';
 import { useConnections } from './useConnections';
 import { useSession } from './useSession';
@@ -98,9 +98,7 @@ export const useConnectionActions = () => {
         grantHandoff?.unifiedApi ?? selectedConnection?.unified_api;
 
       let completed = false;
-      let timer: ReturnType<typeof setInterval> | undefined;
-      let graceTimeout: ReturnType<typeof setTimeout> | undefined;
-      let cancelCallablePoll: (() => void) | undefined;
+      let cancelCloseWatch: (() => void) | undefined;
 
       const handleChildWindowClose = () => {
         mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
@@ -114,12 +112,19 @@ export const useConnectionActions = () => {
       const cleanup = () => {
         completed = true;
         window.removeEventListener('message', handler);
-        if (timer) clearInterval(timer);
-        if (graceTimeout) clearTimeout(graceTimeout);
-        cancelCallablePoll?.();
-        cancelCallablePoll = undefined;
+        cancelCloseWatch?.();
+        cancelCloseWatch = undefined;
         cleanupRef.current = null;
         setIsReAuthorizing(false);
+      };
+
+      const refreshConnection = () => {
+        mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
+          (result) => {
+            onConnectionChange?.(result?.data);
+          }
+        );
+        mutate('/vault/connections');
       };
 
       const handler = async (event: MessageEvent) => {
@@ -164,102 +169,58 @@ export const useConnectionActions = () => {
           return;
         }
 
-        mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
-          (result) => {
-            onConnectionChange?.(result?.data);
-          }
-        );
-        mutate('/vault/connections');
+        refreshConnection();
         cleanup();
       };
 
       window.addEventListener('message', handler);
       cleanupRef.current = cleanup;
 
-      let child: Window | null;
       if (grantHandoff) {
-        // Grant-handoff flow: open the popup on the launch URL synchronously
-        // (popup blockers) and mint the grant in parallel — the grant is
-        // never awaited before open and never carried in a URL.
-        const { launchUrl, launchOrigin } = deriveLaunchUrl(
+        const child = openGrantHandoffPopup({
           session,
-          grantHandoff.serviceId
-        );
-        child = window.open(
-          launchUrl,
-          '_blank',
-          'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0'
-        );
-        const grantPromise = mintGrant({
           unifiedApi: grantHandoff.unifiedApi,
           serviceId: grantHandoff.serviceId,
           connectionsUrl: connectionsUrl ?? '',
           headers,
+          legacyAuthorizeUrl: url,
         });
-        if (child) {
-          // Fire-and-forget: the handshake removes its own listener and
-          // timer once it resolves ('handoff' or 'legacy' fallback
-          // navigation).
-          runLaunchHandshake({
-            child,
-            launchOrigin,
-            legacyAuthorizeUrl: url,
-            grantPromise,
-          });
-        }
+
+        cancelCloseWatch = watchPopupCloseAndPoll({
+          child,
+          detailUrl: `${connectionsUrl}/${unifiedApi}/${serviceId}`,
+          headers,
+          isCompleted: () => completed,
+          onOutcome: (outcome) => {
+            if (outcome === 'callable') {
+              refreshConnection();
+            } else {
+              addToast({
+                title: t('Authorization was not completed'),
+                description: t(
+                  'The authorization window was closed before the connection became ready. Please try again.'
+                ),
+                type: 'error',
+                autoClose: true,
+              });
+            }
+            cleanup();
+          },
+        }).cancel;
       } else {
         // Revoke (and other non-handoff) call sites: open the URL directly,
-        // exactly as before — no grant mint, no handshake.
-        child = window.open(
-          url,
-          '_blank',
-          'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0'
-        );
-      }
+        // exactly as before — no grant mint, no handshake, no callable poll.
+        const child = window.open(url, '_blank', OAUTH_POPUP_FEATURES);
 
-      timer = setInterval(() => {
-        if (child?.closed) {
-          if (timer) clearInterval(timer);
-          timer = undefined;
-          graceTimeout = setTimeout(() => {
-            if (completed) return;
-            if (!grantHandoff) {
-              handleChildWindowClose();
-              cleanup();
-              return;
-            }
-            // The popup closed without a definitive oauth_complete /
-            // oauth_error message — poll the connection state instead of
-            // blindly reporting success.
-            const { promise, cancel } = pollForCallable({
-              detailUrl: `${connectionsUrl}/${unifiedApi}/${serviceId}`,
-              headers,
-            });
-            cancelCallablePoll = cancel;
-            promise.then((outcome) => {
-              cancelCallablePoll = undefined;
-              if (outcome === 'callable') {
-                mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
-                  (result) => {
-                    onConnectionChange?.(result?.data);
-                  }
-                );
-                mutate('/vault/connections');
-              } else {
-                addToast({
-                  title: t('Authorization was not completed'),
-                  description: t(
-                    'The authorization window was closed before the connection became ready. Please try again.'
-                  ),
-                  type: 'error',
-                  autoClose: true,
-                });
-              }
-              cleanup();
-            });
-          }, 1000);
-        }
-      }, 500);
+        cancelCloseWatch = watchPopupClose({
+          child,
+          isCompleted: () => completed,
+          onClosed: () => {
+            handleChildWindowClose();
+            cleanup();
+          },
+        }).cancel;
+      }
     }
   };
 

--- a/src/utils/connectionActions.ts
+++ b/src/utils/connectionActions.ts
@@ -7,11 +7,21 @@ import { ConnectionViewType } from '../types/ConnectionViewType';
 import { OAuthPostMessage } from '../types/OAuthCsrf';
 import { SessionSettings, VaultAction } from '../types/Session';
 import { callConfirmEndpoint } from './oauthCsrf';
+import {
+  deriveLaunchUrl,
+  mintGrant,
+  pollForCallable,
+  runLaunchHandshake,
+} from './oauthGrantHandoff';
 import { useConnections } from './useConnections';
+import { useSession } from './useSession';
 
 export const useConnectionActions = () => {
   const { selectedConnection, updateConnection, connectionsUrl, headers } =
     useConnections();
+  // May be undefined when no SessionProvider is mounted — deriveLaunchUrl
+  // falls back to the default REDIRECT_URL origin in that case.
+  const { session } = useSession();
   const [isReAuthorizing, setIsReAuthorizing] = useState(false);
   const { mutate } = useSWRConfig();
   const { addToast } = useToast();
@@ -35,7 +45,8 @@ export const useConnectionActions = () => {
 
   const handleRedirect = async (
     url: string,
-    onConnectionChange?: (connection: Connection) => any
+    onConnectionChange?: (connection: Connection) => any,
+    grantHandoff?: { unifiedApi: string; serviceId: string }
   ) => {
     setIsReAuthorizing(true);
     if (
@@ -81,12 +92,15 @@ export const useConnectionActions = () => {
         setIsReAuthorizing(false);
       }
     } else {
-      const serviceId = selectedConnection?.service_id;
-      const unifiedApi = selectedConnection?.unified_api;
+      const serviceId =
+        grantHandoff?.serviceId ?? selectedConnection?.service_id;
+      const unifiedApi =
+        grantHandoff?.unifiedApi ?? selectedConnection?.unified_api;
 
       let completed = false;
       let timer: ReturnType<typeof setInterval> | undefined;
       let graceTimeout: ReturnType<typeof setTimeout> | undefined;
+      let cancelCallablePoll: (() => void) | undefined;
 
       const handleChildWindowClose = () => {
         mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
@@ -102,6 +116,8 @@ export const useConnectionActions = () => {
         window.removeEventListener('message', handler);
         if (timer) clearInterval(timer);
         if (graceTimeout) clearTimeout(graceTimeout);
+        cancelCallablePoll?.();
+        cancelCallablePoll = undefined;
         cleanupRef.current = null;
         setIsReAuthorizing(false);
       };
@@ -160,21 +176,87 @@ export const useConnectionActions = () => {
       window.addEventListener('message', handler);
       cleanupRef.current = cleanup;
 
-      const child = window.open(
-        url,
-        '_blank',
-        'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0'
-      );
+      let child: Window | null;
+      if (grantHandoff) {
+        // Grant-handoff flow: open the popup on the launch URL synchronously
+        // (popup blockers) and mint the grant in parallel — the grant is
+        // never awaited before open and never carried in a URL.
+        const { launchUrl, launchOrigin } = deriveLaunchUrl(
+          session,
+          grantHandoff.serviceId
+        );
+        child = window.open(
+          launchUrl,
+          '_blank',
+          'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0'
+        );
+        const grantPromise = mintGrant({
+          unifiedApi: grantHandoff.unifiedApi,
+          serviceId: grantHandoff.serviceId,
+          connectionsUrl: connectionsUrl ?? '',
+          headers,
+        });
+        if (child) {
+          // Fire-and-forget: the handshake removes its own listener and
+          // timer once it resolves ('handoff' or 'legacy' fallback
+          // navigation).
+          runLaunchHandshake({
+            child,
+            launchOrigin,
+            legacyAuthorizeUrl: url,
+            grantPromise,
+          });
+        }
+      } else {
+        // Revoke (and other non-handoff) call sites: open the URL directly,
+        // exactly as before — no grant mint, no handshake.
+        child = window.open(
+          url,
+          '_blank',
+          'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0'
+        );
+      }
 
       timer = setInterval(() => {
         if (child?.closed) {
           if (timer) clearInterval(timer);
           timer = undefined;
           graceTimeout = setTimeout(() => {
-            if (!completed) {
+            if (completed) return;
+            if (!grantHandoff) {
               handleChildWindowClose();
               cleanup();
+              return;
             }
+            // The popup closed without a definitive oauth_complete /
+            // oauth_error message — poll the connection state instead of
+            // blindly reporting success.
+            const { promise, cancel } = pollForCallable({
+              detailUrl: `${connectionsUrl}/${unifiedApi}/${serviceId}`,
+              headers,
+            });
+            cancelCallablePoll = cancel;
+            promise.then((outcome) => {
+              cancelCallablePoll = undefined;
+              if (outcome === 'callable') {
+                mutate(`${connectionsUrl}/${unifiedApi}/${serviceId}`).then(
+                  (result) => {
+                    onConnectionChange?.(result?.data);
+                  }
+                );
+                mutate('/vault/connections');
+              } else {
+                addToast({
+                  title: t('Authorization was not completed'),
+                  description: t(
+                    'The authorization window was closed before the connection became ready. Please try again.'
+                  ),
+                  type: 'error',
+                  autoClose: true,
+                });
+              }
+              cleanup();
+            });
           }, 1000);
         }
       }, 500);

--- a/src/utils/oauthGrantHandoff.ts
+++ b/src/utils/oauthGrantHandoff.ts
@@ -1,0 +1,198 @@
+/**
+ * OAuth grant-handoff utilities — the widget side of the vault `oauth/launch`
+ * contract.
+ *
+ * Background and design rationale:
+ * - thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md
+ * - thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md
+ *
+ * Invariants:
+ * - The grant is NEVER carried in a URL (no query params, no fragments).
+ * - The opener → popup postMessage handshake (with an explicit, pinned
+ *   `targetOrigin`) is the ONLY delivery channel for the grant.
+ * - The legacy `oauth_complete` path remains intact as the fallback: any
+ *   failure to mint a grant or to complete the handshake degrades to
+ *   navigating the popup to the legacy authorize URL, never to a broken click.
+ */
+import {
+  CALLABLE_POLL_BUDGET_MS,
+  CALLABLE_POLL_INTERVAL_MS,
+  LAUNCH_READY_TIMEOUT_MS,
+} from '../constants/oauthGrantHandoff';
+import { OAUTH_LAUNCH_PATH, REDIRECT_URL } from '../constants/urls';
+import {
+  GrantResponse,
+  HandshakeOutcome,
+  LaunchReadyMessage,
+  LaunchStartMessage,
+  PollOutcome,
+} from '../types/OAuthGrantHandoff';
+
+/**
+ * Mint a single-use grant for the given connection. Returns the grant string
+ * on success and `null` on any failure (non-2xx, network error, malformed
+ * body). Never throws — a failed mint is the signal to fall back to the
+ * legacy flow, not to break the click.
+ */
+export async function mintGrant(params: {
+  unifiedApi: string;
+  serviceId: string;
+  connectionsUrl: string;
+  headers: Record<string, string>;
+}): Promise<string | null> {
+  const url = `${params.connectionsUrl}/${params.unifiedApi}/${params.serviceId}/grant`;
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...params.headers,
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as GrantResponse;
+    return body?.data?.grant ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive the popup launch URL and its origin from the session's
+ * `redirect_uri` (falling back to the default REDIRECT_URL). The launch URL
+ * carries only a non-secret `service_id` for correlation — never a grant.
+ * The returned `launchOrigin` is the pin used to validate the handshake.
+ */
+export function deriveLaunchUrl(
+  session: { redirect_uri?: string } | null | undefined,
+  serviceId: string
+): { launchUrl: string; launchOrigin: string } {
+  const launchOrigin = new URL(session?.redirect_uri ?? REDIRECT_URL).origin;
+  const launchUrl = `${launchOrigin}${OAUTH_LAUNCH_PATH}?service_id=${encodeURIComponent(
+    serviceId
+  )}`;
+  return { launchUrl, launchOrigin };
+}
+
+/**
+ * Run the opener-side launch handshake against an already-opened popup
+ * (opening the window stays synchronous at the call site).
+ *
+ * - On a valid `oauth_launch_ready` (same window as `child`, origin equal to
+ *   `launchOrigin`) the minted grant is awaited and posted to the popup as an
+ *   `oauth_launch_start` message with the pinned targetOrigin → 'handoff'.
+ * - If the grant is null, or no valid ready arrives within
+ *   LAUNCH_READY_TIMEOUT_MS, the popup is navigated to the legacy authorize
+ *   URL instead → 'legacy'.
+ *
+ * Resolves exactly once; the message listener and timer are always cleaned
+ * up on resolution.
+ */
+export function runLaunchHandshake(params: {
+  child: Window;
+  launchOrigin: string;
+  legacyAuthorizeUrl: string;
+  grantPromise: Promise<string | null>;
+}): Promise<HandshakeOutcome> {
+  const { child, launchOrigin, legacyAuthorizeUrl, grantPromise } = params;
+
+  return new Promise<HandshakeOutcome>((resolve) => {
+    let settled = false;
+    let readyHandled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const settle = (outcome: HandshakeOutcome) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      window.removeEventListener('message', onMessage);
+      resolve(outcome);
+    };
+
+    const fallBackToLegacy = () => {
+      if (settled) return;
+      child.location.href = legacyAuthorizeUrl;
+      settle('legacy');
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (settled || readyHandled) return;
+      const data = event.data as Partial<LaunchReadyMessage> | undefined;
+      if (data?.type !== 'oauth_launch_ready') return;
+      if (event.source !== child) return;
+      if (event.origin !== launchOrigin) return;
+
+      readyHandled = true;
+      grantPromise.then(
+        (grant) => {
+          if (settled) return;
+          if (grant) {
+            const message: LaunchStartMessage = {
+              type: 'oauth_launch_start',
+              grant,
+              authorizeUrl: legacyAuthorizeUrl,
+            };
+            child.postMessage(message, launchOrigin);
+            settle('handoff');
+          } else {
+            fallBackToLegacy();
+          }
+        },
+        () => fallBackToLegacy()
+      );
+    };
+
+    window.addEventListener('message', onMessage);
+    timer = setTimeout(fallBackToLegacy, LAUNCH_READY_TIMEOUT_MS);
+  });
+}
+
+/**
+ * Poll the connection detail endpoint until its state becomes `callable`,
+ * the poll budget elapses ('timeout'), or `cancel()` is invoked (the promise
+ * then simply never settles). Transient fetch/JSON errors are swallowed and
+ * polling continues.
+ */
+export function pollForCallable(params: {
+  detailUrl: string;
+  headers: Record<string, string>;
+}): { promise: Promise<PollOutcome>; cancel: () => void } {
+  let interval: ReturnType<typeof setInterval> | undefined;
+  let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+  let settled = false;
+
+  const stopTimers = () => {
+    if (interval !== undefined) clearInterval(interval);
+    if (budgetTimer !== undefined) clearTimeout(budgetTimer);
+  };
+
+  const promise = new Promise<PollOutcome>((resolve) => {
+    const settle = (outcome: PollOutcome) => {
+      if (settled) return;
+      settled = true;
+      stopTimers();
+      resolve(outcome);
+    };
+
+    interval = setInterval(() => {
+      fetch(params.detailUrl, { headers: params.headers })
+        .then((response) => response.json())
+        .then((body) => {
+          if (settled) return;
+          if (body?.data?.state === 'callable') settle('callable');
+        })
+        .catch(() => {
+          // Transient error — keep polling until budget or cancel.
+        });
+    }, CALLABLE_POLL_INTERVAL_MS);
+
+    budgetTimer = setTimeout(() => settle('timeout'), CALLABLE_POLL_BUDGET_MS);
+  });
+
+  const cancel = () => {
+    settled = true;
+    stopTimers();
+  };
+
+  return { promise, cancel };
+}

--- a/src/utils/oauthGrantHandoff.ts
+++ b/src/utils/oauthGrantHandoff.ts
@@ -174,16 +174,17 @@ export function pollForCallable(params: {
       resolve(outcome);
     };
 
-    interval = setInterval(() => {
-      fetch(params.detailUrl, { headers: params.headers })
-        .then((response) => response.json())
-        .then((body) => {
-          if (settled) return;
-          if (body?.data?.state === 'callable') settle('callable');
-        })
-        .catch(() => {
-          // Transient error — keep polling until budget or cancel.
+    interval = setInterval(async () => {
+      try {
+        const response = await fetch(params.detailUrl, {
+          headers: params.headers,
         });
+        const body = await response.json();
+        if (settled) return;
+        if (body?.data?.state === 'callable') settle('callable');
+      } catch {
+        // Transient error — keep polling until budget or cancel.
+      }
     }, CALLABLE_POLL_INTERVAL_MS);
 
     budgetTimer = setTimeout(() => settle('timeout'), CALLABLE_POLL_BUDGET_MS);

--- a/src/utils/oauthGrantHandoff.ts
+++ b/src/utils/oauthGrantHandoff.ts
@@ -6,6 +6,20 @@
  * - thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md
  * - thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md
  *
+ * Fallback ladder for confirming the authorization (strongest first):
+ * 1. sessionStorage self-confirm — vault's callback page finds the grant that
+ *    its launch page stashed in sessionStorage and confirms the connection
+ *    itself, without involving the opener.
+ * 2. Legacy opener postMessage — the callback posts `oauth_complete` to the
+ *    opener, which calls the confirm endpoint (the pre-handoff flow).
+ * 3. Loud error — neither channel completed; after the popup closes the
+ *    widget polls the connection state and surfaces an actionable error toast
+ *    instead of silently reporting success.
+ *
+ * Deployment-order dependency (each layer degrades gracefully until the next
+ * one is live): unify grant endpoints → vault launch page/callback →
+ * vault-core release.
+ *
  * Invariants:
  * - The grant is NEVER carried in a URL (no query params, no fragments).
  * - The opener → popup postMessage handshake (with an explicit, pinned
@@ -18,6 +32,9 @@ import {
   CALLABLE_POLL_BUDGET_MS,
   CALLABLE_POLL_INTERVAL_MS,
   LAUNCH_READY_TIMEOUT_MS,
+  OAUTH_POPUP_FEATURES,
+  POPUP_CLOSE_CHECK_INTERVAL_MS,
+  POPUP_CLOSE_GRACE_MS,
 } from '../constants/oauthGrantHandoff';
 import { OAUTH_LAUNCH_PATH, REDIRECT_URL } from '../constants/urls';
 import {
@@ -196,4 +213,117 @@ export function pollForCallable(params: {
   };
 
   return { promise, cancel };
+}
+
+/**
+ * Open the grant-handoff popup and kick off the flow: open the vault launch
+ * page synchronously (popup blockers), mint the grant in parallel (never
+ * awaited before open, never carried in a URL), and run the launch handshake
+ * fire-and-forget — it removes its own listener and timer once it resolves
+ * ('handoff', or 'legacy' fallback navigation).
+ *
+ * Returns the popup window (`null` when the popup was blocked) so the caller
+ * can watch it for close.
+ */
+export function openGrantHandoffPopup(params: {
+  session: { redirect_uri?: string } | null | undefined;
+  unifiedApi: string;
+  serviceId: string;
+  connectionsUrl: string;
+  headers: Record<string, string>;
+  legacyAuthorizeUrl: string;
+}): Window | null {
+  const { launchUrl, launchOrigin } = deriveLaunchUrl(
+    params.session,
+    params.serviceId
+  );
+  const child = window.open(launchUrl, '_blank', OAUTH_POPUP_FEATURES);
+  const grantPromise = mintGrant({
+    unifiedApi: params.unifiedApi,
+    serviceId: params.serviceId,
+    connectionsUrl: params.connectionsUrl,
+    headers: params.headers,
+  });
+  if (child) {
+    runLaunchHandshake({
+      child,
+      launchOrigin,
+      legacyAuthorizeUrl: params.legacyAuthorizeUrl,
+      grantPromise,
+    });
+  }
+  return child;
+}
+
+/**
+ * Watch a popup for close. Once it closes, wait POPUP_CLOSE_GRACE_MS (gives
+ * an in-flight `oauth_complete` / `oauth_error` message time to arrive and
+ * settle the flow first), then invoke `onClosed` — unless `isCompleted()`
+ * reports the flow already finished. `cancel()` stops the watcher without
+ * invoking `onClosed`.
+ */
+export function watchPopupClose(params: {
+  child: Window | null;
+  isCompleted: () => boolean;
+  onClosed: () => void;
+}): { cancel: () => void } {
+  let graceTimer: ReturnType<typeof setTimeout> | undefined;
+  let interval: ReturnType<typeof setInterval> | undefined = setInterval(() => {
+    if (!params.child?.closed) return;
+    if (interval !== undefined) clearInterval(interval);
+    interval = undefined;
+    graceTimer = setTimeout(() => {
+      if (params.isCompleted()) return;
+      params.onClosed();
+    }, POPUP_CLOSE_GRACE_MS);
+  }, POPUP_CLOSE_CHECK_INTERVAL_MS);
+
+  return {
+    cancel: () => {
+      if (interval !== undefined) clearInterval(interval);
+      if (graceTimer !== undefined) clearTimeout(graceTimer);
+    },
+  };
+}
+
+/**
+ * Watch a popup for close and, once the grace period elapses without the
+ * flow completing, poll the connection detail endpoint for state `callable`
+ * (the popup closed without a definitive `oauth_complete` / `oauth_error`
+ * message, so poll instead of blindly reporting success). `onOutcome`
+ * receives 'callable' or 'timeout'; `cancel()` stops the watcher and any
+ * in-flight poll without invoking `onOutcome`.
+ */
+export function watchPopupCloseAndPoll(params: {
+  child: Window | null;
+  detailUrl: string;
+  headers: Record<string, string>;
+  isCompleted: () => boolean;
+  onOutcome: (outcome: PollOutcome) => void;
+}): { cancel: () => void } {
+  let cancelPoll: (() => void) | undefined;
+
+  const watcher = watchPopupClose({
+    child: params.child,
+    isCompleted: params.isCompleted,
+    onClosed: () => {
+      const { promise, cancel } = pollForCallable({
+        detailUrl: params.detailUrl,
+        headers: params.headers,
+      });
+      cancelPoll = cancel;
+      promise.then((outcome) => {
+        cancelPoll = undefined;
+        params.onOutcome(outcome);
+      });
+    },
+  });
+
+  return {
+    cancel: () => {
+      watcher.cancel();
+      cancelPoll?.();
+      cancelPoll = undefined;
+    },
+  };
 }

--- a/test/authorize-button.test.tsx
+++ b/test/authorize-button.test.tsx
@@ -476,4 +476,114 @@ describe('Authorize button OAuth CSRF flow', () => {
     ).length;
     expect(confirmCallsAfter).toBe(confirmCallsBefore);
   });
+
+  // --- Storage-partitioned iframe (GH-9546) ---------------------------------
+  // When Vault is embedded in a third-party iframe, sessionStorage is commonly
+  // partitioned away: writes are dropped or throw, and reads return null. The
+  // authorize -> /confirm path must not depend on it. These guard against
+  // reintroducing any sessionStorage dependency (the example/iframe-test harness
+  // reproduces the same two failure modes manually).
+
+  const renderAndWaitForAuthorize = async () => {
+    const mockData = setupOAuthFetchMock(SERVICE_ID);
+    let screen: any;
+    await act(async () => {
+      screen = render(
+        <Vault
+          token="token123"
+          open
+          unifiedApi={UNIFIED_API}
+          serviceId={SERVICE_ID}
+        />
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Authorize')).toBeInTheDocument();
+    });
+    return { screen, mockData };
+  };
+
+  const dispatchComplete = async (nonce: string) => {
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'oauth_complete',
+            nonce,
+            confirmToken: 'token-xyz',
+            serviceId: SERVICE_ID,
+            success: true,
+          },
+          origin: 'https://vault.apideck.com',
+        })
+      );
+    });
+  };
+
+  it('still opens the popup and POSTs /confirm when sessionStorage throws (denied storage)', async () => {
+    const { screen, mockData } = await renderAndWaitForAuthorize();
+
+    // Sever storage only after mount, simulating a storage-blocked iframe.
+    const setItem = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('Access is denied.', 'SecurityError');
+      });
+    const getItem = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new DOMException('Access is denied.', 'SecurityError');
+      });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Authorize'));
+    });
+
+    // Click handler no longer touches storage, so the popup still opens.
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    await dispatchComplete('arbitrary-value');
+
+    await waitFor(() => {
+      const c = mockData.calls.find((c) =>
+        c.url.endsWith(`/${UNIFIED_API}/${SERVICE_ID}/confirm`)
+      );
+      expect(c).toBeDefined();
+      expect(JSON.parse(c?.init?.body as string)).toEqual({
+        confirm_token: 'token-xyz',
+      });
+    });
+
+    // The OAuth path is storage-independent: it never read or wrote storage.
+    expect(setItem).not.toHaveBeenCalled();
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  it('still POSTs /confirm when sessionStorage is severed (writes dropped, reads null)', async () => {
+    const { screen, mockData } = await renderAndWaitForAuthorize();
+
+    const setItem = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => undefined);
+    const getItem = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockReturnValue(null);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Authorize'));
+    });
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    await dispatchComplete('arbitrary-value');
+
+    await waitFor(() => {
+      const c = mockData.calls.find((c) =>
+        c.url.endsWith(`/${UNIFIED_API}/${SERVICE_ID}/confirm`)
+      );
+      expect(c).toBeDefined();
+    });
+
+    expect(setItem).not.toHaveBeenCalled();
+    expect(getItem).not.toHaveBeenCalled();
+  });
 });

--- a/test/authorize-button.test.tsx
+++ b/test/authorize-button.test.tsx
@@ -10,6 +10,12 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { Vault } from '../src/components/Vault';
 import { act } from 'react-dom/test-utils';
 import { CONFIG } from './responses/config';
+import {
+  CALLABLE_POLL_BUDGET_MS,
+  CALLABLE_POLL_INTERVAL_MS,
+  LAUNCH_READY_TIMEOUT_MS,
+} from '../src/constants/oauthGrantHandoff';
+import { OAUTH_LAUNCH_PATH, REDIRECT_URL } from '../src/constants/urls';
 
 const makeConnection = (serviceId: string, overrides: Record<string, any>) => ({
   id: `ecommerce+${serviceId}`,
@@ -149,9 +155,82 @@ const SERVICE_ID = 'shopify';
 const UNIFIED_API = 'ecommerce';
 const CONNECTIONS_URL = 'https://unify.apideck.com/vault/connections';
 
+// The Vault test harness uses a non-JWT token ("token123"), so the decoded
+// session is empty and `session.redirect_uri` is unset — the launch origin
+// falls back to the REDIRECT_URL origin (https://vault.apideck.com).
+const LAUNCH_ORIGIN = new URL(REDIRECT_URL).origin;
+const LAUNCH_URL = `${LAUNCH_ORIGIN}${OAUTH_LAUNCH_PATH}?service_id=${SERVICE_ID}`;
+const WINDOW_FEATURES =
+  'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0';
+const AUTHORIZE_URL_PREFIX = `https://unify.apideck.com/vault/authorize/${SERVICE_ID}/abc`;
+const DETAIL_URL = `${CONNECTIONS_URL}/${UNIFIED_API}/${SERVICE_ID}`;
+
+type FakeChild = {
+  closed: boolean;
+  close: jest.Mock;
+  postMessage: jest.Mock;
+  location: { href: string };
+};
+
+const makeFakeChild = (): FakeChild => ({
+  closed: false,
+  close: jest.fn(),
+  postMessage: jest.fn(),
+  location: { href: '' },
+});
+
+const dispatchLaunchReady = async (child: FakeChild) => {
+  await act(async () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'oauth_launch_ready' },
+        origin: LAUNCH_ORIGIN,
+        source: child as any,
+      })
+    );
+  });
+};
+
+// Complete the opener -> popup handshake and return the legacy authorize URL
+// (containing the nonce) that the widget posted to the child.
+const completeHandshake = async (child: FakeChild) => {
+  await dispatchLaunchReady(child);
+  await waitFor(() => {
+    expect(child.postMessage).toHaveBeenCalled();
+  });
+  return child.postMessage.mock.calls[0][0].authorizeUrl as string;
+};
+
+const dispatchComplete = async (nonce: string) => {
+  await act(async () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'oauth_complete',
+          nonce,
+          confirmToken: 'token-xyz',
+          serviceId: SERVICE_ID,
+          success: true,
+        },
+        origin: 'https://vault.apideck.com',
+      })
+    );
+  });
+};
+
+interface OAuthMockOptions {
+  // 'success' (default) responds with a grant; 'failure' responds non-2xx;
+  // 'pending' leaves the request unresolved until `releaseGrant` is invoked.
+  grant?: 'success' | 'failure' | 'pending';
+  // Initial connection state served by the detail endpoint (mutable per test
+  // via the returned `detailState` field).
+  detailState?: string;
+}
+
 const setupOAuthFetchMock = (
   serviceId: string,
-  overrides: Record<string, any> = {}
+  overrides: Record<string, any> = {},
+  options: OAuthMockOptions = {}
 ) => {
   const connection = makeConnection(serviceId, {
     auth_type: 'oauth2',
@@ -160,16 +239,43 @@ const setupOAuthFetchMock = (
     ...overrides,
   });
   const listResponse = { status_code: 200, status: 'OK', data: [connection] };
-  const detailResponse = { status_code: 200, status: 'OK', data: connection };
   const confirmResponse = {
     status_code: 200,
     status: 'OK',
     data: { confirmed: true },
   };
+  const grantResponse = {
+    status_code: 200,
+    status: 'OK',
+    data: { grant: 'grant-abc', expires_in: 300 },
+  };
 
   const calls: { url: string; init?: any }[] = [];
+  const mockData = {
+    calls,
+    // Mutable: tests flip this to drive the post-close callable poll.
+    detailState: options.detailState ?? ((connection as any).state as string),
+    releaseGrant: undefined as (() => void) | undefined,
+  };
+
   (window.fetch as any).mockImplementation((url: string, init?: any) => {
     calls.push({ url, init });
+    if (url.endsWith('/grant') && init?.method === 'POST') {
+      if (options.grant === 'failure') {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ message: 'grant unavailable' }),
+        };
+      }
+      if (options.grant === 'pending') {
+        return new Promise((resolve) => {
+          mockData.releaseGrant = () =>
+            resolve({ ok: true, status: 200, json: async () => grantResponse });
+        });
+      }
+      return { ok: true, status: 200, json: async () => grantResponse };
+    }
     if (url.endsWith('/confirm') && init?.method === 'POST') {
       return {
         ok: true,
@@ -178,7 +284,15 @@ const setupOAuthFetchMock = (
       };
     }
     if (url === `${CONNECTIONS_URL}/ecommerce/${serviceId}`) {
-      return { ok: true, status: 200, json: async () => detailResponse };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status_code: 200,
+          status: 'OK',
+          data: { ...connection, state: mockData.detailState },
+        }),
+      };
     }
     if (url.includes('/config')) {
       return { ok: true, status: 200, json: async () => CONFIG };
@@ -186,17 +300,17 @@ const setupOAuthFetchMock = (
     return { ok: true, status: 200, json: async () => listResponse };
   });
 
-  return { calls };
+  return mockData;
 };
 
 describe('Authorize button OAuth CSRF flow', () => {
-  let fakeChild: { closed: boolean; close: jest.Mock };
+  let fakeChild: FakeChild;
   let openSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.spyOn(window, 'fetch');
     setupIntersectionObserverMock();
-    fakeChild = { closed: false, close: jest.fn() };
+    fakeChild = makeFakeChild();
     openSpy = jest
       .spyOn(window, 'open')
       .mockImplementation(() => fakeChild as unknown as Window);
@@ -239,10 +353,12 @@ describe('Authorize button OAuth CSRF flow', () => {
     await renderAndClickAuthorize();
 
     expect(openSpy).toHaveBeenCalledTimes(1);
-    const openedUrl = openSpy.mock.calls[0][0] as string;
-    expect(openedUrl).toContain('nonce=');
+    // Phase 5: the popup opens on the launch URL; the legacy authorize URL
+    // (carrying the nonce) is delivered to the child via the handshake.
+    const authorizeUrl = await completeHandshake(fakeChild);
+    expect(authorizeUrl).toContain('nonce=');
 
-    const url = new URL(openedUrl);
+    const url = new URL(authorizeUrl);
     const nonceFromUrl = url.searchParams.get('nonce');
     expect(nonceFromUrl).toBeTruthy();
   });
@@ -250,8 +366,10 @@ describe('Authorize button OAuth CSRF flow', () => {
   it('on oauth_complete with valid nonce: POSTs to /confirm', async () => {
     const { mockData } = await renderAndClickAuthorize();
 
-    const openedUrl = openSpy.mock.calls[0][0] as string;
-    const nonce = new URL(openedUrl).searchParams.get('nonce') as string;
+    // Phase 5: the opened URL is the launch URL; obtain the legacy authorize
+    // URL (with nonce) by completing the handshake.
+    const authorizeUrl = await completeHandshake(fakeChild);
+    const nonce = new URL(authorizeUrl).searchParams.get('nonce') as string;
 
     await act(async () => {
       window.dispatchEvent(
@@ -308,8 +426,9 @@ describe('Authorize button OAuth CSRF flow', () => {
   it('ignores postMessage with foreign serviceId', async () => {
     const { mockData } = await renderAndClickAuthorize();
 
-    const openedUrl = openSpy.mock.calls[0][0] as string;
-    const nonce = new URL(openedUrl).searchParams.get('nonce') as string;
+    // Phase 5: read the nonce from the authorize URL posted to the child.
+    const authorizeUrl = await completeHandshake(fakeChild);
+    const nonce = new URL(authorizeUrl).searchParams.get('nonce') as string;
 
     await act(async () => {
       window.dispatchEvent(
@@ -439,7 +558,12 @@ describe('Authorize button OAuth CSRF flow', () => {
       fireEvent.click(screen.getByText('Authorize'));
     });
 
-    const openedUrl = openSpy.mock.calls[0][0] as string;
+    // Phase 5: force the ready-timeout fallback so the child is navigated to
+    // the legacy authorize URL, then read the nonce from it.
+    await act(async () => {
+      jest.advanceTimersByTime(LAUNCH_READY_TIMEOUT_MS);
+    });
+    const openedUrl = fakeChild.location.href;
     const nonce = new URL(openedUrl).searchParams.get('nonce') as string;
 
     await act(async () => {
@@ -501,23 +625,6 @@ describe('Authorize button OAuth CSRF flow', () => {
       expect(screen.getByText('Authorize')).toBeInTheDocument();
     });
     return { screen, mockData };
-  };
-
-  const dispatchComplete = async (nonce: string) => {
-    await act(async () => {
-      window.dispatchEvent(
-        new MessageEvent('message', {
-          data: {
-            type: 'oauth_complete',
-            nonce,
-            confirmToken: 'token-xyz',
-            serviceId: SERVICE_ID,
-            success: true,
-          },
-          origin: 'https://vault.apideck.com',
-        })
-      );
-    });
   };
 
   it('still opens the popup and POSTs /confirm when sessionStorage throws (denied storage)', async () => {
@@ -585,5 +692,345 @@ describe('Authorize button OAuth CSRF flow', () => {
 
     expect(setItem).not.toHaveBeenCalled();
     expect(getItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('Authorize button OAuth grant handoff flow', () => {
+  let fakeChild: FakeChild;
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.spyOn(window, 'fetch');
+    setupIntersectionObserverMock();
+    fakeChild = makeFakeChild();
+    openSpy = jest
+      .spyOn(window, 'open')
+      .mockImplementation(() => fakeChild as unknown as Window);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const renderVaultAndWaitForAuthorize = async (
+    options: OAuthMockOptions = {},
+    vaultProps: Record<string, any> = {}
+  ) => {
+    const mockData = setupOAuthFetchMock(SERVICE_ID, {}, options);
+    let screen: any;
+    await act(async () => {
+      screen = render(
+        <Vault
+          token="token123"
+          open
+          unifiedApi={UNIFIED_API}
+          serviceId={SERVICE_ID}
+          {...(vaultProps as any)}
+        />
+      );
+    });
+    if (jest.isMockFunction(setTimeout)) {
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+    }
+    await waitFor(() => {
+      expect(screen.getByText('Authorize')).toBeInTheDocument();
+    });
+    return { screen, mockData };
+  };
+
+  const clickAuthorize = async (screen: any) => {
+    await act(async () => {
+      fireEvent.click(screen.getByText('Authorize'));
+    });
+  };
+
+  const detailFetchCount = (calls: { url: string; init?: any }[]) =>
+    calls.filter((c) => c.url === DETAIL_URL && c.init?.method === undefined)
+      .length;
+
+  it('opens the popup to the launch URL synchronously on click, before the grant mint resolves', async () => {
+    const { screen, mockData } = await renderVaultAndWaitForAuthorize({
+      grant: 'pending',
+    });
+
+    await clickAuthorize(screen);
+
+    // The popup must open synchronously on the launch URL — the grant mock is
+    // still unresolved here (it only resolves via releaseGrant).
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(LAUNCH_URL, '_blank', WINDOW_FEATURES);
+
+    const grantCall = mockData.calls.find((c) => c.url.endsWith('/grant'));
+    expect(grantCall).toBeDefined();
+    expect(mockData.releaseGrant).toBeDefined();
+  });
+
+  it('still mints the grant with a POST to .../grant carrying the JWT headers', async () => {
+    const { screen, mockData } = await renderVaultAndWaitForAuthorize();
+
+    await clickAuthorize(screen);
+
+    await waitFor(() => {
+      const grantCall = mockData.calls.find(
+        (c) => c.url === `${DETAIL_URL}/grant`
+      );
+      expect(grantCall).toBeDefined();
+      expect(grantCall?.init?.method).toBe('POST');
+
+      // The mint must carry the same JWT headers as every other Vault API
+      // call in this harness (e.g. the SWR connection fetches).
+      const authenticatedCall = mockData.calls.find(
+        (c) => c.url === DETAIL_URL && c.init?.headers?.Authorization
+      );
+      expect(authenticatedCall).toBeDefined();
+      expect(grantCall?.init?.headers).toMatchObject({
+        Authorization: authenticatedCall?.init?.headers?.Authorization,
+        'X-APIDECK-AUTH-TYPE': 'JWT',
+      });
+    });
+  });
+
+  it('on oauth_launch_ready from the child at the launch origin: posts oauth_launch_start with grant + legacy authorize URL (containing &nonce=) and explicit targetOrigin', async () => {
+    const { screen } = await renderVaultAndWaitForAuthorize();
+
+    await clickAuthorize(screen);
+    await dispatchLaunchReady(fakeChild);
+
+    await waitFor(() => {
+      expect(fakeChild.postMessage).toHaveBeenCalledTimes(1);
+    });
+
+    const [message, targetOrigin] = fakeChild.postMessage.mock.calls[0];
+    expect(targetOrigin).toBe(LAUNCH_ORIGIN);
+    expect(message).toMatchObject({
+      type: 'oauth_launch_start',
+      grant: 'grant-abc',
+    });
+    expect(message.authorizeUrl).toContain(AUTHORIZE_URL_PREFIX);
+    expect(message.authorizeUrl).toContain(`redirect_uri=${REDIRECT_URL}`);
+    expect(message.authorizeUrl).toContain('nonce=');
+    expect(
+      new URL(message.authorizeUrl).searchParams.get('nonce')
+    ).toBeTruthy();
+    // The child was never navigated: the grant travels via postMessage only.
+    expect(fakeChild.location.href).toBe('');
+  });
+
+  it('when the grant mint returns non-2xx: navigates the popup to the legacy authorize URL and the legacy oauth_complete → /confirm path still works end-to-end', async () => {
+    const { screen, mockData } = await renderVaultAndWaitForAuthorize({
+      grant: 'failure',
+    });
+
+    await clickAuthorize(screen);
+    await dispatchLaunchReady(fakeChild);
+
+    await waitFor(() => {
+      expect(fakeChild.location.href).not.toBe('');
+    });
+    const legacyUrl = fakeChild.location.href;
+    expect(legacyUrl).toContain(AUTHORIZE_URL_PREFIX);
+    const nonce = new URL(legacyUrl).searchParams.get('nonce') as string;
+    expect(nonce).toBeTruthy();
+    expect(fakeChild.postMessage).not.toHaveBeenCalled();
+
+    await dispatchComplete(nonce);
+
+    await waitFor(() => {
+      const confirmCall = mockData.calls.find((c) =>
+        c.url.endsWith(`/${UNIFIED_API}/${SERVICE_ID}/confirm`)
+      );
+      expect(confirmCall).toBeDefined();
+      expect(confirmCall?.init?.method).toBe('POST');
+      expect(JSON.parse(confirmCall?.init?.body as string)).toEqual({
+        confirm_token: 'token-xyz',
+      });
+    });
+  });
+
+  it('when no oauth_launch_ready arrives within LAUNCH_READY_TIMEOUT_MS: navigates the popup to the legacy authorize URL', async () => {
+    jest.useFakeTimers();
+    const { screen } = await renderVaultAndWaitForAuthorize();
+
+    await clickAuthorize(screen);
+
+    await act(async () => {
+      jest.advanceTimersByTime(LAUNCH_READY_TIMEOUT_MS);
+    });
+
+    expect(fakeChild.location.href).toContain(AUTHORIZE_URL_PREFIX);
+    expect(
+      new URL(fakeChild.location.href).searchParams.get('nonce')
+    ).toBeTruthy();
+    expect(fakeChild.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('legacy oauth_complete received after a completed handoff handshake: still POSTs /confirm exactly once (popup-side fallback; no double confirm with the poller)', async () => {
+    jest.useFakeTimers();
+    const { screen, mockData } = await renderVaultAndWaitForAuthorize();
+
+    await clickAuthorize(screen);
+    const authorizeUrl = await completeHandshake(fakeChild);
+    const nonce = new URL(authorizeUrl).searchParams.get('nonce') as string;
+
+    await dispatchComplete(nonce);
+
+    await waitFor(() => {
+      expect(
+        mockData.calls.filter((c) => c.url.endsWith('/confirm')).length
+      ).toBe(1);
+    });
+
+    // The popup closes afterwards — the completed flag keeps the close-poller
+    // (and the callable poll) from double reporting.
+    fakeChild.closed = true;
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+    const ticks = CALLABLE_POLL_BUDGET_MS / CALLABLE_POLL_INTERVAL_MS;
+    for (let i = 0; i <= ticks; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      });
+    }
+
+    expect(
+      mockData.calls.filter((c) => c.url.endsWith('/confirm')).length
+    ).toBe(1);
+    expect(screen.queryByText(/not completed/i)).not.toBeInTheDocument();
+  });
+
+  it('on popup close after handoff without oauth_complete: polls the connection detail URL and, on state=callable, mutates and fires onConnectionChange without an error toast', async () => {
+    jest.useFakeTimers();
+    const onConnectionChange = jest.fn();
+    const { screen, mockData } = await renderVaultAndWaitForAuthorize(
+      { detailState: 'pending_confirmation' },
+      { onConnectionChange }
+    );
+
+    await clickAuthorize(screen);
+    await completeHandshake(fakeChild);
+    onConnectionChange.mockClear();
+
+    fakeChild.closed = true;
+    // 500ms close poll + 1000ms grace, as today.
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Still pending_confirmation: no blind mutate success — the widget must
+    // poll the detail URL instead of reporting success immediately.
+    expect(onConnectionChange).not.toHaveBeenCalled();
+
+    const fetchesBeforePoll = detailFetchCount(mockData.calls);
+    await act(async () => {
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+    });
+    expect(detailFetchCount(mockData.calls)).toBeGreaterThan(fetchesBeforePoll);
+
+    mockData.detailState = 'callable';
+    await act(async () => {
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+    });
+
+    await waitFor(() => {
+      expect(onConnectionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'callable' })
+      );
+    });
+    expect(screen.queryByText(/not completed/i)).not.toBeInTheDocument();
+  });
+
+  it('on popup close with the connection stuck pending_confirmation: shows an actionable error toast after the poll budget, never a silent success', async () => {
+    jest.useFakeTimers();
+    const onConnectionChange = jest.fn();
+    const { screen, mockData } = await renderVaultAndWaitForAuthorize(
+      { detailState: 'pending_confirmation' },
+      { onConnectionChange }
+    );
+
+    await clickAuthorize(screen);
+    await completeHandshake(fakeChild);
+    onConnectionChange.mockClear();
+
+    fakeChild.closed = true;
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const ticks = CALLABLE_POLL_BUDGET_MS / CALLABLE_POLL_INTERVAL_MS;
+    for (let i = 0; i <= ticks; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      });
+    }
+
+    // Actionable error toast — never a silent fake success.
+    expect(screen.getByText(/not completed/i)).toBeInTheDocument();
+    expect(onConnectionChange).not.toHaveBeenCalled();
+    expect(
+      mockData.calls.find((c) => c.url.endsWith('/confirm'))
+    ).toBeUndefined();
+  });
+
+  it('on oauth_error: toasts, does not confirm, and does not start the callable poll', async () => {
+    jest.useFakeTimers();
+    const { screen, mockData } = await renderVaultAndWaitForAuthorize();
+
+    await clickAuthorize(screen);
+
+    // The handoff flow opened the popup on the launch URL.
+    expect(openSpy).toHaveBeenCalledWith(LAUNCH_URL, '_blank', WINDOW_FEATURES);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'oauth_error',
+            error: 'access_denied',
+            errorDescription: 'User denied consent',
+            serviceId: SERVICE_ID,
+          },
+          origin: LAUNCH_ORIGIN,
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('User denied consent')).toBeInTheDocument();
+    });
+
+    const fetchesAfterError = detailFetchCount(mockData.calls);
+
+    fakeChild.closed = true;
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      });
+    }
+
+    // No callable poll started after the grace window.
+    expect(detailFetchCount(mockData.calls)).toBe(fetchesAfterError);
+    expect(
+      mockData.calls.find((c) => c.url.endsWith('/confirm'))
+    ).toBeUndefined();
   });
 });

--- a/test/connection-actions.test.tsx
+++ b/test/connection-actions.test.tsx
@@ -313,4 +313,95 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
     confirmCall = calls.find((c) => c.url.endsWith('/confirm'));
     expect(confirmCall).toBeUndefined();
   });
+
+  // --- Storage-partitioned iframe (GH-9546) ---------------------------------
+  // handleRedirect must confirm even when the embedding iframe has no usable
+  // sessionStorage (writes dropped/throw, reads null). Guards against
+  // reintroducing a storage dependency in the redirect -> /confirm path.
+
+  const renderTriggerHost = () =>
+    renderHost({
+      url: AUTHORIZE_URL_BASE,
+      buildUrlAtClick: (_serviceId, base) => {
+        const u = new URL(base);
+        u.searchParams.append('nonce', generateNonce());
+        return u.href;
+      },
+    });
+
+  const clickAndComplete = async (result: ReturnType<typeof renderTriggerHost>) => {
+    await act(async () => {
+      fireEvent.click(result.getByText('Trigger'));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'oauth_complete',
+            nonce: 'arbitrary-value',
+            confirmToken: 'token-xyz',
+            serviceId: SERVICE_ID,
+            success: true,
+          },
+          origin: 'https://vault.apideck.com',
+        })
+      );
+    });
+
+    await waitFor(() => {
+      const c = result.calls.find((c) =>
+        c.url.endsWith(`/${UNIFIED_API}/${SERVICE_ID}/confirm`)
+      );
+      expect(c).toBeDefined();
+    });
+  };
+
+  it('still POSTs /confirm when sessionStorage throws (denied storage)', async () => {
+    const result = renderTriggerHost();
+    // Let the single-connection auto-select effect settle before severing storage.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const setItem = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('Access is denied.', 'SecurityError');
+      });
+    const getItem = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new DOMException('Access is denied.', 'SecurityError');
+      });
+
+    await clickAndComplete(result);
+
+    expect(setItem).not.toHaveBeenCalled();
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  it('still POSTs /confirm when sessionStorage is severed (writes dropped, reads null)', async () => {
+    const result = renderTriggerHost();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const setItem = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => undefined);
+    const getItem = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockReturnValue(null);
+
+    await clickAndComplete(result);
+
+    expect(setItem).not.toHaveBeenCalled();
+    expect(getItem).not.toHaveBeenCalled();
+  });
 });

--- a/test/connection-actions.test.tsx
+++ b/test/connection-actions.test.tsx
@@ -10,6 +10,12 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { ConnectionsProvider } from '../src/utils/useConnections';
 import { useConnectionActions } from '../src/utils/connectionActions';
 import { generateNonce } from '../src/utils/oauthCsrf';
+import {
+  CALLABLE_POLL_BUDGET_MS,
+  CALLABLE_POLL_INTERVAL_MS,
+  LAUNCH_READY_TIMEOUT_MS,
+} from '../src/constants/oauthGrantHandoff';
+import { OAUTH_LAUNCH_PATH, REDIRECT_URL } from '../src/constants/urls';
 import '../src/utils/i18n';
 
 const SERVICE_ID = 'shopify';
@@ -17,6 +23,69 @@ const UNIFIED_API = 'ecommerce';
 const UNIFY_BASE_URL = 'https://unify.apideck.com';
 const CONNECTIONS_URL = `${UNIFY_BASE_URL}/vault/connections`;
 const AUTHORIZE_URL_BASE = `${CONNECTIONS_URL}/authorize/${SERVICE_ID}/abc?redirect_uri=http://localhost:3000`;
+const DETAIL_URL = `${CONNECTIONS_URL}/${UNIFIED_API}/${SERVICE_ID}`;
+const GRANT_URL = `${DETAIL_URL}/grant`;
+
+// No SessionProvider is mounted in this harness, so the session has no
+// redirect_uri — the launch origin falls back to the REDIRECT_URL origin
+// (https://vault.apideck.com).
+const LAUNCH_ORIGIN = new URL(REDIRECT_URL).origin;
+const LAUNCH_URL = `${LAUNCH_ORIGIN}${OAUTH_LAUNCH_PATH}?service_id=${SERVICE_ID}`;
+const WINDOW_FEATURES =
+  'location=no,height=750,width=550,scrollbars=yes,status=yes,left=0,top=0';
+
+type FakeChild = {
+  closed: boolean;
+  close: jest.Mock;
+  postMessage: jest.Mock;
+  location: { href: string };
+};
+
+const makeFakeChild = (): FakeChild => ({
+  closed: false,
+  close: jest.fn(),
+  postMessage: jest.fn(),
+  location: { href: '' },
+});
+
+const dispatchLaunchReady = async (child: FakeChild) => {
+  await act(async () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'oauth_launch_ready' },
+        origin: LAUNCH_ORIGIN,
+        source: child as any,
+      })
+    );
+  });
+};
+
+// Complete the opener -> popup handshake and return the legacy authorize URL
+// (containing the nonce) that the widget posted to the child.
+const completeHandshake = async (child: FakeChild) => {
+  await dispatchLaunchReady(child);
+  await waitFor(() => {
+    expect(child.postMessage).toHaveBeenCalled();
+  });
+  return child.postMessage.mock.calls[0][0].authorizeUrl as string;
+};
+
+const dispatchComplete = async (nonce: string) => {
+  await act(async () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'oauth_complete',
+          nonce,
+          confirmToken: 'token-xyz',
+          serviceId: SERVICE_ID,
+          success: true,
+        },
+        origin: 'https://vault.apideck.com',
+      })
+    );
+  });
+};
 
 const makeConnection = (overrides: Record<string, any> = {}) => ({
   id: `${UNIFIED_API}+${SERVICE_ID}`,
@@ -40,9 +109,18 @@ const makeConnection = (overrides: Record<string, any> = {}) => ({
 interface HostProps {
   url: string;
   buildUrlAtClick?: (serviceId: string, base: string) => string;
+  // Phase 5 adds a third `grantHandoff` param to handleRedirect; re-authorize
+  // call sites pass it, revoke call sites do not.
+  withGrantHandoff?: boolean;
+  onConnectionChange?: (connection: any) => any;
 }
 
-const Host = ({ url, buildUrlAtClick }: HostProps) => {
+const Host = ({
+  url,
+  buildUrlAtClick,
+  withGrantHandoff,
+  onConnectionChange,
+}: HostProps) => {
   const { handleRedirect } = useConnectionActions();
   return (
     <button
@@ -50,7 +128,15 @@ const Host = ({ url, buildUrlAtClick }: HostProps) => {
         const finalUrl = buildUrlAtClick
           ? buildUrlAtClick(SERVICE_ID, url)
           : url;
-        handleRedirect(finalUrl);
+        if (withGrantHandoff) {
+          // Phase 5 adds this param — cast until the signature gains it.
+          (handleRedirect as any)(finalUrl, onConnectionChange, {
+            unifiedApi: UNIFIED_API,
+            serviceId: SERVICE_ID,
+          });
+        } else {
+          handleRedirect(finalUrl, onConnectionChange);
+        }
       }}
     >
       Trigger
@@ -58,13 +144,22 @@ const Host = ({ url, buildUrlAtClick }: HostProps) => {
   );
 };
 
+interface MockOptions {
+  // 'success' (default) responds with a grant; 'failure' responds non-2xx;
+  // 'pending' leaves the request unresolved until `releaseGrant` is invoked.
+  grant?: 'success' | 'failure' | 'pending';
+  // Initial connection state served by the detail endpoint (mutable per test
+  // via the returned `mockData.detailState` field).
+  detailState?: string;
+}
+
 const renderHost = (
   hostProps: HostProps,
-  connectionOverrides: Record<string, any> = {}
+  connectionOverrides: Record<string, any> = {},
+  options: MockOptions = {}
 ) => {
   const connection = makeConnection(connectionOverrides);
   const listResponse = { status_code: 200, status: 'OK', data: [connection] };
-  const detailResponse = { status_code: 200, status: 'OK', data: connection };
   const tokenResponse = {
     status_code: 200,
     status: 'OK',
@@ -75,10 +170,38 @@ const renderHost = (
     status: 'OK',
     data: { confirmed: true },
   };
+  const grantResponse = {
+    status_code: 200,
+    status: 'OK',
+    data: { grant: 'grant-abc', expires_in: 300 },
+  };
 
   const calls: { url: string; init?: any }[] = [];
+  const mockData = {
+    calls,
+    // Mutable: tests flip this to drive the post-close callable poll.
+    detailState: options.detailState ?? ((connection as any).state as string),
+    releaseGrant: undefined as (() => void) | undefined,
+  };
+
   (window.fetch as any).mockImplementation((url: string, init?: any) => {
     calls.push({ url, init });
+    if (url === GRANT_URL && init?.method === 'POST') {
+      if (options.grant === 'failure') {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ message: 'grant unavailable' }),
+        };
+      }
+      if (options.grant === 'pending') {
+        return new Promise((resolve) => {
+          mockData.releaseGrant = () =>
+            resolve({ ok: true, status: 200, json: async () => grantResponse });
+        });
+      }
+      return { ok: true, status: 200, json: async () => grantResponse };
+    }
     if (url.endsWith('/confirm') && init?.method === 'POST') {
       return { ok: true, status: 200, json: async () => confirmResponse };
     }
@@ -86,13 +209,22 @@ const renderHost = (
       return { ok: true, status: 200, json: async () => tokenResponse };
     }
     if (url === `${CONNECTIONS_URL}/${UNIFIED_API}/${SERVICE_ID}`) {
-      return { ok: true, status: 200, json: async () => detailResponse };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status_code: 200,
+          status: 'OK',
+          data: { ...connection, state: mockData.detailState },
+        }),
+      };
     }
     return { ok: true, status: 200, json: async () => listResponse };
   });
 
   return {
     calls,
+    mockData,
     ...render(
       <ToastProvider>
         <ConnectionsProvider
@@ -113,12 +245,12 @@ const renderHost = (
 };
 
 describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
-  let fakeChild: { closed: boolean; close: jest.Mock };
+  let fakeChild: FakeChild;
   let openSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.spyOn(window, 'fetch');
-    fakeChild = { closed: false, close: jest.fn() };
+    fakeChild = makeFakeChild();
     openSpy = jest
       .spyOn(window, 'open')
       .mockImplementation(() => fakeChild as unknown as Window);
@@ -131,6 +263,7 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
   });
 
   const triggerAndOpen = async () => {
+    // Re-authorize flow: Phase 5 passes the grantHandoff param here.
     const result = renderHost({
       url: AUTHORIZE_URL_BASE,
       buildUrlAtClick: (_serviceId, base) => {
@@ -139,6 +272,7 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
         u.searchParams.append('nonce', nonce);
         return u.href;
       },
+      withGrantHandoff: true,
     });
 
     await act(async () => {
@@ -157,17 +291,21 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
     await triggerAndOpen();
 
     expect(openSpy).toHaveBeenCalledTimes(1);
-    const openedUrl = openSpy.mock.calls[0][0] as string;
-    expect(openedUrl).toContain('nonce=');
-    const nonceFromUrl = new URL(openedUrl).searchParams.get('nonce');
+    // Phase 5: the popup opens on the launch URL; the legacy authorize URL
+    // (carrying the nonce) is delivered to the child via the handshake.
+    const authorizeUrl = await completeHandshake(fakeChild);
+    expect(authorizeUrl).toContain('nonce=');
+    const nonceFromUrl = new URL(authorizeUrl).searchParams.get('nonce');
     expect(nonceFromUrl).toBeTruthy();
   });
 
   it('on oauth_complete with valid nonce: POSTs to /confirm', async () => {
     const { calls } = await triggerAndOpen();
 
-    const openedUrl = openSpy.mock.calls[0][0] as string;
-    const nonce = new URL(openedUrl).searchParams.get('nonce') as string;
+    // Phase 5: the opened URL is the launch URL; obtain the legacy authorize
+    // URL (with nonce) by completing the handshake.
+    const authorizeUrl = await completeHandshake(fakeChild);
+    const nonce = new URL(authorizeUrl).searchParams.get('nonce') as string;
 
     await act(async () => {
       window.dispatchEvent(
@@ -224,8 +362,9 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
   it('ignores postMessage with foreign serviceId', async () => {
     const { calls } = await triggerAndOpen();
 
-    const openedUrl = openSpy.mock.calls[0][0] as string;
-    const nonce = new URL(openedUrl).searchParams.get('nonce') as string;
+    // Phase 5: read the nonce from the authorize URL posted to the child.
+    const authorizeUrl = await completeHandshake(fakeChild);
+    const nonce = new URL(authorizeUrl).searchParams.get('nonce') as string;
 
     await act(async () => {
       window.dispatchEvent(
@@ -291,6 +430,7 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
         u.searchParams.append('nonce', nonce);
         return u.href;
       },
+      withGrantHandoff: true,
     });
 
     await act(async () => {
@@ -327,9 +467,12 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
         u.searchParams.append('nonce', generateNonce());
         return u.href;
       },
+      withGrantHandoff: true,
     });
 
-  const clickAndComplete = async (result: ReturnType<typeof renderTriggerHost>) => {
+  const clickAndComplete = async (
+    result: ReturnType<typeof renderTriggerHost>
+  ) => {
     await act(async () => {
       fireEvent.click(result.getByText('Trigger'));
     });
@@ -403,5 +546,381 @@ describe('useConnectionActions.handleRedirect OAuth CSRF flow', () => {
 
     expect(setItem).not.toHaveBeenCalled();
     expect(getItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('useConnectionActions.handleRedirect OAuth grant handoff flow', () => {
+  let fakeChild: FakeChild;
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.spyOn(window, 'fetch');
+    fakeChild = makeFakeChild();
+    openSpy = jest
+      .spyOn(window, 'open')
+      .mockImplementation(() => fakeChild as unknown as Window);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const appendNonce = (_serviceId: string, base: string) => {
+    const u = new URL(base);
+    u.searchParams.append('nonce', generateNonce());
+    return u.href;
+  };
+
+  const renderHandoffHost = (
+    options: MockOptions = {},
+    hostExtras: Partial<HostProps> = {}
+  ) =>
+    renderHost(
+      {
+        url: AUTHORIZE_URL_BASE,
+        buildUrlAtClick: appendNonce,
+        withGrantHandoff: true,
+        ...hostExtras,
+      },
+      {},
+      options
+    );
+
+  const clickTrigger = async (result: { getByText: any }) => {
+    await act(async () => {
+      fireEvent.click(result.getByText('Trigger'));
+    });
+    // Allow effects (selectedConnection auto-set in single-connection mode)
+    // to flush.
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
+  const detailFetchCount = (calls: { url: string; init?: any }[]) =>
+    calls.filter((c) => c.url === DETAIL_URL && c.init?.method === undefined)
+      .length;
+
+  it('opens the popup to the launch URL synchronously on click, before the grant mint resolves', async () => {
+    const result = renderHandoffHost({ grant: 'pending' });
+
+    await clickTrigger(result);
+
+    // The popup must open synchronously on the launch URL — the grant mock is
+    // still unresolved here (it only resolves via releaseGrant).
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(LAUNCH_URL, '_blank', WINDOW_FEATURES);
+
+    const grantCall = result.calls.find((c) => c.url === GRANT_URL);
+    expect(grantCall).toBeDefined();
+    expect(result.mockData.releaseGrant).toBeDefined();
+  });
+
+  it('still mints the grant with a POST to .../grant carrying the JWT headers', async () => {
+    const result = renderHandoffHost();
+
+    await clickTrigger(result);
+
+    await waitFor(() => {
+      const grantCall = result.calls.find((c) => c.url === GRANT_URL);
+      expect(grantCall).toBeDefined();
+      expect(grantCall?.init?.method).toBe('POST');
+      expect(grantCall?.init?.headers).toMatchObject({
+        Authorization: 'Bearer jwt-token',
+        'X-APIDECK-APP-ID': 'app-id',
+        'X-APIDECK-CONSUMER-ID': 'consumer-id',
+      });
+    });
+  });
+
+  it('on oauth_launch_ready from the child at the launch origin: posts oauth_launch_start with grant + legacy authorize URL (containing &nonce=) and explicit targetOrigin', async () => {
+    const result = renderHandoffHost();
+
+    await clickTrigger(result);
+    await dispatchLaunchReady(fakeChild);
+
+    await waitFor(() => {
+      expect(fakeChild.postMessage).toHaveBeenCalledTimes(1);
+    });
+
+    const [message, targetOrigin] = fakeChild.postMessage.mock.calls[0];
+    expect(targetOrigin).toBe(LAUNCH_ORIGIN);
+    expect(message).toMatchObject({
+      type: 'oauth_launch_start',
+      grant: 'grant-abc',
+    });
+    expect(message.authorizeUrl).toContain(
+      `${CONNECTIONS_URL}/authorize/${SERVICE_ID}/abc`
+    );
+    expect(message.authorizeUrl).toContain('nonce=');
+    expect(
+      new URL(message.authorizeUrl).searchParams.get('nonce')
+    ).toBeTruthy();
+    // The child was never navigated: the grant travels via postMessage only.
+    expect(fakeChild.location.href).toBe('');
+  });
+
+  it('when the grant mint returns non-2xx: navigates the popup to the legacy authorize URL and the legacy oauth_complete → /confirm path still works end-to-end', async () => {
+    const result = renderHandoffHost({ grant: 'failure' });
+
+    await clickTrigger(result);
+    await dispatchLaunchReady(fakeChild);
+
+    await waitFor(() => {
+      expect(fakeChild.location.href).not.toBe('');
+    });
+    const legacyUrl = fakeChild.location.href;
+    expect(legacyUrl).toContain(
+      `${CONNECTIONS_URL}/authorize/${SERVICE_ID}/abc`
+    );
+    const nonce = new URL(legacyUrl).searchParams.get('nonce') as string;
+    expect(nonce).toBeTruthy();
+    expect(fakeChild.postMessage).not.toHaveBeenCalled();
+
+    await dispatchComplete(nonce);
+
+    await waitFor(() => {
+      const confirmCall = result.calls.find((c) =>
+        c.url.endsWith(`/${UNIFIED_API}/${SERVICE_ID}/confirm`)
+      );
+      expect(confirmCall).toBeDefined();
+      expect(confirmCall?.init?.method).toBe('POST');
+      expect(JSON.parse(confirmCall?.init?.body as string)).toEqual({
+        confirm_token: 'token-xyz',
+      });
+    });
+  });
+
+  it('when no oauth_launch_ready arrives within LAUNCH_READY_TIMEOUT_MS: navigates the popup to the legacy authorize URL', async () => {
+    jest.useFakeTimers();
+    const result = renderHandoffHost();
+
+    await clickTrigger(result);
+
+    await act(async () => {
+      jest.advanceTimersByTime(LAUNCH_READY_TIMEOUT_MS);
+    });
+
+    expect(fakeChild.location.href).toContain(
+      `${CONNECTIONS_URL}/authorize/${SERVICE_ID}/abc`
+    );
+    expect(
+      new URL(fakeChild.location.href).searchParams.get('nonce')
+    ).toBeTruthy();
+    expect(fakeChild.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('legacy oauth_complete received after a completed handoff handshake: still POSTs /confirm exactly once (popup-side fallback; no double confirm with the poller)', async () => {
+    jest.useFakeTimers();
+    const result = renderHandoffHost();
+
+    await clickTrigger(result);
+    const authorizeUrl = await completeHandshake(fakeChild);
+    const nonce = new URL(authorizeUrl).searchParams.get('nonce') as string;
+
+    await dispatchComplete(nonce);
+
+    await waitFor(() => {
+      expect(
+        result.calls.filter((c) => c.url.endsWith('/confirm')).length
+      ).toBe(1);
+    });
+
+    // The popup closes afterwards — the completed flag keeps the close-poller
+    // (and the callable poll) from double reporting.
+    fakeChild.closed = true;
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+    const ticks = CALLABLE_POLL_BUDGET_MS / CALLABLE_POLL_INTERVAL_MS;
+    for (let i = 0; i <= ticks; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      });
+    }
+
+    expect(result.calls.filter((c) => c.url.endsWith('/confirm')).length).toBe(
+      1
+    );
+    expect(result.queryByText(/not completed/i)).not.toBeInTheDocument();
+  });
+
+  it('on popup close after handoff without oauth_complete: polls the connection detail URL and, on state=callable, mutates and fires onConnectionChange without an error toast', async () => {
+    jest.useFakeTimers();
+    const onConnectionChange = jest.fn();
+    const result = renderHandoffHost(
+      { detailState: 'pending_confirmation' },
+      { onConnectionChange }
+    );
+
+    await clickTrigger(result);
+    await completeHandshake(fakeChild);
+    onConnectionChange.mockClear();
+
+    fakeChild.closed = true;
+    // 500ms close poll + 1000ms grace, as today.
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Still pending_confirmation: no blind mutate success — the widget must
+    // poll the detail URL instead of reporting success immediately.
+    expect(onConnectionChange).not.toHaveBeenCalled();
+
+    const fetchesBeforePoll = detailFetchCount(result.calls);
+    await act(async () => {
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+    });
+    expect(detailFetchCount(result.calls)).toBeGreaterThan(fetchesBeforePoll);
+
+    result.mockData.detailState = 'callable';
+    await act(async () => {
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+    });
+
+    await waitFor(() => {
+      expect(onConnectionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'callable' })
+      );
+    });
+    expect(result.queryByText(/not completed/i)).not.toBeInTheDocument();
+  });
+
+  it('on popup close with the connection stuck pending_confirmation: shows an actionable error toast after the poll budget, never a silent success', async () => {
+    jest.useFakeTimers();
+    const onConnectionChange = jest.fn();
+    const result = renderHandoffHost(
+      { detailState: 'pending_confirmation' },
+      { onConnectionChange }
+    );
+
+    await clickTrigger(result);
+    await completeHandshake(fakeChild);
+    onConnectionChange.mockClear();
+
+    fakeChild.closed = true;
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const ticks = CALLABLE_POLL_BUDGET_MS / CALLABLE_POLL_INTERVAL_MS;
+    for (let i = 0; i <= ticks; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      });
+    }
+
+    // Actionable error toast — never a silent fake success.
+    expect(result.getByText(/not completed/i)).toBeInTheDocument();
+    expect(onConnectionChange).not.toHaveBeenCalled();
+    expect(
+      result.calls.find((c) => c.url.endsWith('/confirm'))
+    ).toBeUndefined();
+  });
+
+  it('on oauth_error: toasts, does not confirm, and does not start the callable poll', async () => {
+    jest.useFakeTimers();
+    const result = renderHandoffHost();
+
+    await clickTrigger(result);
+
+    // The handoff flow opened the popup on the launch URL.
+    expect(openSpy).toHaveBeenCalledWith(LAUNCH_URL, '_blank', WINDOW_FEATURES);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'oauth_error',
+            error: 'access_denied',
+            errorDescription: 'User denied consent',
+            serviceId: SERVICE_ID,
+          },
+          origin: LAUNCH_ORIGIN,
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.queryByText('User denied consent')).toBeInTheDocument();
+    });
+
+    const fetchesAfterError = detailFetchCount(result.calls);
+
+    fakeChild.closed = true;
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      });
+    }
+
+    // No callable poll started after the grace window.
+    expect(detailFetchCount(result.calls)).toBe(fetchesAfterError);
+    expect(
+      result.calls.find((c) => c.url.endsWith('/confirm'))
+    ).toBeUndefined();
+  });
+
+  it('revoke/disconnect: opens the revoke URL directly — no grant mint, no handshake listener, no callable poll', async () => {
+    jest.useFakeTimers();
+    const revokeUrl = `${UNIFY_BASE_URL}/vault/revoke/${SERVICE_ID}/abc?redirect_uri=http://localhost:3000`;
+    // No grantHandoff param at revoke call sites — today's behavior
+    // byte-for-byte.
+    const result = renderHost({ url: revokeUrl });
+
+    await act(async () => {
+      fireEvent.click(result.getByText('Trigger'));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(revokeUrl, '_blank', WINDOW_FEATURES);
+
+    // No grant mint.
+    expect(result.calls.find((c) => c.url === GRANT_URL)).toBeUndefined();
+
+    // A launch-ready message is ignored — no handshake listener is armed.
+    await dispatchLaunchReady(fakeChild);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fakeChild.postMessage).not.toHaveBeenCalled();
+    expect(fakeChild.location.href).toBe('');
+
+    // On close, today's single mutate may run after the grace window, but no
+    // repeated callable poll may start.
+    fakeChild.closed = true;
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+    const fetchesAfterGrace = detailFetchCount(result.calls);
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      });
+    }
+    expect(detailFetchCount(result.calls)).toBe(fetchesAfterGrace);
   });
 });

--- a/test/oauth-grant-handoff.test.ts
+++ b/test/oauth-grant-handoff.test.ts
@@ -1,0 +1,470 @@
+import '@testing-library/jest-dom/extend-expect';
+import 'whatwg-fetch';
+
+import {
+  CALLABLE_POLL_BUDGET_MS,
+  CALLABLE_POLL_INTERVAL_MS,
+  LAUNCH_READY_TIMEOUT_MS,
+} from '../src/constants/oauthGrantHandoff';
+import { OAUTH_LAUNCH_PATH, REDIRECT_URL } from '../src/constants/urls';
+import {
+  deriveLaunchUrl,
+  mintGrant,
+  pollForCallable,
+  runLaunchHandshake,
+} from '../src/utils/oauthGrantHandoff';
+
+// Flush pending microtasks (fetch/json chains) without relying on real
+// timers — safe to use while jest fake timers are installed.
+const flushPromises = async (rounds = 6) => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+};
+
+describe('oauthGrantHandoff utilities', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('mintGrant', () => {
+    const baseParams = {
+      unifiedApi: 'crm',
+      serviceId: 'salesforce',
+      connectionsUrl: 'https://unify.apideck.com/vault/connections',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'X-APIDECK-APP-ID': 'app-id',
+        'X-APIDECK-CONSUMER-ID': 'consumer-id',
+      },
+    };
+
+    it('POSTs to {connectionsUrl}/{unifiedApi}/{serviceId}/grant with the provided headers and returns the grant string on 2xx', async () => {
+      const grantResponse = {
+        status_code: 200,
+        status: 'OK',
+        data: { grant: 'grant-token-123', expires_in: 60 },
+      };
+      const fetchSpy = jest.spyOn(window, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => grantResponse,
+      } as any);
+
+      const result = await mintGrant(baseParams);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toBe(
+        'https://unify.apideck.com/vault/connections/crm/salesforce/grant'
+      );
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toMatchObject({
+        Authorization: 'Bearer test-token',
+        'X-APIDECK-APP-ID': 'app-id',
+        'X-APIDECK-CONSUMER-ID': 'consumer-id',
+        'Content-Type': 'application/json',
+      });
+      expect(result).toBe('grant-token-123');
+    });
+
+    it('returns null on non-2xx response (grant flow unavailable → caller falls back to legacy)', async () => {
+      jest.spyOn(window, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({ message: 'Unknown endpoint' }),
+      } as any);
+
+      const result = await mintGrant(baseParams);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when fetch rejects (network error) instead of throwing', async () => {
+      jest
+        .spyOn(window, 'fetch')
+        .mockRejectedValue(new TypeError('Network request failed'));
+
+      await expect(mintGrant(baseParams)).resolves.toBeNull();
+    });
+  });
+
+  describe('deriveLaunchUrl', () => {
+    it('builds {origin(redirect_uri)}{OAUTH_LAUNCH_PATH}?service_id=... from a session redirect_uri', () => {
+      const session = {
+        redirect_uri: 'https://vault.eu.apideck.com/oauth/callback?foo=bar',
+      };
+
+      const { launchUrl, launchOrigin } = deriveLaunchUrl(
+        session,
+        'salesforce'
+      );
+
+      expect(launchOrigin).toBe('https://vault.eu.apideck.com');
+      expect(launchUrl).toBe(
+        `https://vault.eu.apideck.com${OAUTH_LAUNCH_PATH}?service_id=salesforce`
+      );
+    });
+
+    it('falls back to the REDIRECT_URL origin when session has no redirect_uri', () => {
+      const expectedOrigin = new URL(REDIRECT_URL).origin;
+
+      const noSession = deriveLaunchUrl(undefined, 'salesforce');
+      expect(noSession.launchOrigin).toBe(expectedOrigin);
+      expect(noSession.launchUrl).toBe(
+        `${expectedOrigin}${OAUTH_LAUNCH_PATH}?service_id=salesforce`
+      );
+
+      const emptySession = deriveLaunchUrl({}, 'salesforce');
+      expect(emptySession.launchOrigin).toBe(expectedOrigin);
+      expect(emptySession.launchUrl).toBe(
+        `${expectedOrigin}${OAUTH_LAUNCH_PATH}?service_id=salesforce`
+      );
+    });
+
+    it('never includes a grant parameter regardless of inputs', () => {
+      const sessions = [
+        undefined,
+        null,
+        {},
+        { redirect_uri: 'https://vault.eu.apideck.com/oauth/callback' },
+        {
+          redirect_uri:
+            'https://vault.apideck.com/oauth/callback?grant=leaky-grant',
+        },
+      ];
+
+      sessions.forEach((session) => {
+        const { launchUrl } = deriveLaunchUrl(session as any, 'salesforce');
+
+        expect(new URL(launchUrl).searchParams.has('grant')).toBe(false);
+        expect(launchUrl).not.toContain('grant');
+      });
+    });
+  });
+
+  describe('runLaunchHandshake', () => {
+    const launchOrigin = 'https://vault.apideck.com';
+    const legacyAuthorizeUrl =
+      'https://example.com/oauth/authorize?state=xyz&client_id=abc';
+
+    const makeChild = () => ({
+      postMessage: jest.fn(),
+      location: { href: '' },
+    });
+
+    const dispatchReady = (source: unknown, origin: string = launchOrigin) => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'oauth_launch_ready' },
+          origin,
+          source: source as any,
+        })
+      );
+    };
+
+    it("posts oauth_launch_start with the grant and legacy authorize URL to the child with explicit targetOrigin after a valid ready message, and resolves 'handoff'", async () => {
+      jest.useFakeTimers();
+      const child = makeChild();
+
+      const promise = runLaunchHandshake({
+        child: child as unknown as Window,
+        launchOrigin,
+        legacyAuthorizeUrl,
+        grantPromise: Promise.resolve('grant-token-123'),
+      });
+
+      dispatchReady(child);
+
+      await expect(promise).resolves.toBe('handoff');
+      expect(child.postMessage).toHaveBeenCalledTimes(1);
+      expect(child.postMessage).toHaveBeenCalledWith(
+        {
+          type: 'oauth_launch_start',
+          grant: 'grant-token-123',
+          authorizeUrl: legacyAuthorizeUrl,
+        },
+        launchOrigin
+      );
+      // The child must not have been navigated to the legacy URL.
+      expect(child.location.href).toBe('');
+    });
+
+    it('ignores a ready message whose event.source is not the opened child', async () => {
+      jest.useFakeTimers();
+      const child = makeChild();
+      const impostor = makeChild();
+
+      const promise = runLaunchHandshake({
+        child: child as unknown as Window,
+        launchOrigin,
+        legacyAuthorizeUrl,
+        grantPromise: Promise.resolve('grant-token-123'),
+      });
+
+      dispatchReady(impostor);
+      await flushPromises();
+
+      expect(child.postMessage).not.toHaveBeenCalled();
+
+      // Without a valid ready message the handshake falls back to legacy.
+      jest.advanceTimersByTime(LAUNCH_READY_TIMEOUT_MS);
+      await expect(promise).resolves.toBe('legacy');
+      expect(child.postMessage).not.toHaveBeenCalled();
+      expect(child.location.href).toBe(legacyAuthorizeUrl);
+    });
+
+    it('ignores a ready message whose event.origin differs from the launch origin', async () => {
+      jest.useFakeTimers();
+      const child = makeChild();
+
+      const promise = runLaunchHandshake({
+        child: child as unknown as Window,
+        launchOrigin,
+        legacyAuthorizeUrl,
+        grantPromise: Promise.resolve('grant-token-123'),
+      });
+
+      dispatchReady(child, 'https://evil.example.com');
+      await flushPromises();
+
+      expect(child.postMessage).not.toHaveBeenCalled();
+
+      // Without a valid ready message the handshake falls back to legacy.
+      jest.advanceTimersByTime(LAUNCH_READY_TIMEOUT_MS);
+      await expect(promise).resolves.toBe('legacy');
+      expect(child.postMessage).not.toHaveBeenCalled();
+      expect(child.location.href).toBe(legacyAuthorizeUrl);
+    });
+
+    it("navigates the child to the legacy authorize URL and resolves 'legacy' when no ready arrives within LAUNCH_READY_TIMEOUT_MS", async () => {
+      jest.useFakeTimers();
+      const child = makeChild();
+
+      const promise = runLaunchHandshake({
+        child: child as unknown as Window,
+        launchOrigin,
+        legacyAuthorizeUrl,
+        grantPromise: Promise.resolve('grant-token-123'),
+      });
+
+      jest.advanceTimersByTime(LAUNCH_READY_TIMEOUT_MS - 1);
+      await flushPromises();
+      expect(child.location.href).toBe('');
+
+      jest.advanceTimersByTime(1);
+      await expect(promise).resolves.toBe('legacy');
+      expect(child.location.href).toBe(legacyAuthorizeUrl);
+      expect(child.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("navigates the child to the legacy authorize URL and resolves 'legacy' when the grant promise resolves null (mint failed)", async () => {
+      jest.useFakeTimers();
+      const child = makeChild();
+
+      const promise = runLaunchHandshake({
+        child: child as unknown as Window,
+        launchOrigin,
+        legacyAuthorizeUrl,
+        grantPromise: Promise.resolve(null),
+      });
+
+      dispatchReady(child);
+
+      await expect(promise).resolves.toBe('legacy');
+      expect(child.location.href).toBe(legacyAuthorizeUrl);
+      expect(child.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('removes its message listener after resolving (both outcomes)', async () => {
+      jest.useFakeTimers();
+      const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+      const messageListenerRemovals = () =>
+        removeEventListenerSpy.mock.calls.filter(([type]) => type === 'message')
+          .length;
+
+      // Handoff outcome
+      const handoffChild = makeChild();
+      const handoffPromise = runLaunchHandshake({
+        child: handoffChild as unknown as Window,
+        launchOrigin,
+        legacyAuthorizeUrl,
+        grantPromise: Promise.resolve('grant-token-123'),
+      });
+      dispatchReady(handoffChild);
+      await expect(handoffPromise).resolves.toBe('handoff');
+      expect(messageListenerRemovals()).toBeGreaterThanOrEqual(1);
+
+      // A late ready message after resolution must do nothing.
+      handoffChild.postMessage.mockClear();
+      dispatchReady(handoffChild);
+      await flushPromises();
+      expect(handoffChild.postMessage).not.toHaveBeenCalled();
+
+      // Legacy outcome
+      const removalsAfterHandoff = messageListenerRemovals();
+      const legacyChild = makeChild();
+      const legacyPromise = runLaunchHandshake({
+        child: legacyChild as unknown as Window,
+        launchOrigin,
+        legacyAuthorizeUrl,
+        grantPromise: Promise.resolve('grant-token-123'),
+      });
+      jest.advanceTimersByTime(LAUNCH_READY_TIMEOUT_MS);
+      await expect(legacyPromise).resolves.toBe('legacy');
+      expect(messageListenerRemovals()).toBeGreaterThan(removalsAfterHandoff);
+
+      // A late ready message after the legacy fallback must do nothing either.
+      dispatchReady(legacyChild);
+      await flushPromises();
+      expect(legacyChild.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pollForCallable', () => {
+    const detailUrl =
+      'https://unify.apideck.com/vault/connections/crm/salesforce';
+    const headers = {
+      Authorization: 'Bearer test-token',
+      'X-APIDECK-APP-ID': 'app-id',
+      'X-APIDECK-CONSUMER-ID': 'consumer-id',
+    };
+
+    const connectionResponse = (state: string) =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status_code: 200,
+          status: 'OK',
+          data: { state },
+        }),
+      } as any);
+
+    it("resolves 'callable' as soon as a poll returns a connection with state 'callable'", async () => {
+      jest.useFakeTimers();
+      const states = ['pending_confirmation', 'pending_confirmation'];
+      const calls: any[] = [];
+      jest.spyOn(window, 'fetch').mockImplementation(((url: any, init: any) => {
+        calls.push([url, init]);
+        return Promise.resolve(
+          connectionResponse(states.shift() ?? 'callable')
+        );
+      }) as any);
+
+      const { promise, cancel } = pollForCallable({ detailUrl, headers });
+      let outcome: string | undefined;
+      promise.then((result) => {
+        outcome = result;
+      });
+
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      await flushPromises();
+      expect(outcome).toBeUndefined();
+
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      await flushPromises();
+      expect(outcome).toBeUndefined();
+
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      await flushPromises();
+      expect(outcome).toBe('callable');
+
+      expect(calls.length).toBe(3);
+      const [url, init] = calls[0];
+      expect(url).toBe(detailUrl);
+      expect(init).toMatchObject({ headers });
+
+      cancel();
+    });
+
+    it("resolves 'timeout' when the poll budget elapses while state stays 'pending_confirmation'", async () => {
+      jest.useFakeTimers();
+      const fetchSpy = jest
+        .spyOn(window, 'fetch')
+        .mockImplementation((() =>
+          Promise.resolve(connectionResponse('pending_confirmation'))) as any);
+
+      const { promise } = pollForCallable({ detailUrl, headers });
+      let outcome: string | undefined;
+      promise.then((result) => {
+        outcome = result;
+      });
+
+      const ticks = CALLABLE_POLL_BUDGET_MS / CALLABLE_POLL_INTERVAL_MS;
+      for (let i = 0; i < ticks; i++) {
+        jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+        await flushPromises();
+      }
+
+      expect(outcome).toBe('timeout');
+
+      // Polling must have stopped once the budget elapsed.
+      const callsAtTimeout = fetchSpy.mock.calls.length;
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS * 3);
+      await flushPromises();
+      expect(fetchSpy.mock.calls.length).toBe(callsAtTimeout);
+    });
+
+    it('keeps polling through a failed fetch (transient error) rather than rejecting', async () => {
+      jest.useFakeTimers();
+      let callCount = 0;
+      jest.spyOn(window, 'fetch').mockImplementation((() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.reject(new TypeError('Network request failed'));
+        }
+        return Promise.resolve(connectionResponse('callable'));
+      }) as any);
+
+      const { promise } = pollForCallable({ detailUrl, headers });
+      let outcome: string | undefined;
+      let rejected = false;
+      promise.then(
+        (result) => {
+          outcome = result;
+        },
+        () => {
+          rejected = true;
+        }
+      );
+
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      await flushPromises();
+      expect(rejected).toBe(false);
+      expect(outcome).toBeUndefined();
+
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      await flushPromises();
+      expect(rejected).toBe(false);
+      expect(outcome).toBe('callable');
+    });
+
+    it('stops polling immediately when the returned cancel function is invoked', async () => {
+      jest.useFakeTimers();
+      const fetchSpy = jest
+        .spyOn(window, 'fetch')
+        .mockImplementation((() =>
+          Promise.resolve(connectionResponse('pending_confirmation'))) as any);
+
+      const { promise, cancel } = pollForCallable({ detailUrl, headers });
+      promise.then(
+        () => undefined,
+        () => undefined
+      );
+
+      jest.advanceTimersByTime(CALLABLE_POLL_INTERVAL_MS);
+      await flushPromises();
+      const callsBeforeCancel = fetchSpy.mock.calls.length;
+      expect(callsBeforeCancel).toBeGreaterThan(0);
+
+      cancel();
+
+      jest.advanceTimersByTime(CALLABLE_POLL_BUDGET_MS * 2);
+      await flushPromises();
+      expect(fetchSpy.mock.calls.length).toBe(callsBeforeCancel);
+    });
+  });
+});

--- a/thoughts/shared/plans/2026-07-17-oauth-confirm-grant-handoff.md
+++ b/thoughts/shared/plans/2026-07-17-oauth-confirm-grant-handoff.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: implemented
 related_research:
   - thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md
   - thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md

--- a/thoughts/shared/plans/2026-07-17-oauth-confirm-grant-handoff.md
+++ b/thoughts/shared/plans/2026-07-17-oauth-confirm-grant-handoff.md
@@ -1,0 +1,383 @@
+---
+status: draft
+related_research:
+  - thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md
+  - thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md
+---
+
+# OAuth Confirm Grant Handoff (vault-core side) Implementation Plan
+
+**Problem**: connections stuck at `pending_confirmation` when COOP severs `window.opener` (deterministic for nested-iframe embedders like OCTA).
+**Design**: forward grant handoff — validated GO on Blink, Gecko, and WebKit via `example/storage-roundtrip/` (results table in its README).
+
+---
+
+## Pattern Decisions
+
+- **New util module** `src/utils/oauthGrantHandoff.ts` — pure, parameter-object functions next to the existing `src/utils/oauthCsrf.ts` (same style as `callConfirmEndpoint`: explicit `connectionsUrl`/`headers` params, no context access inside utils).
+- **Per-call listener lifecycle** — message listeners armed before `window.open`, torn down in `cleanup()`, guarded by a `completed` flag; unchanged pattern (based on: `src/components/AuthorizeButton.tsx:122-173`, `src/utils/connectionActions.ts:109-160`).
+- **Synchronous `window.open` in the click handler** — non-negotiable; the grant is minted in parallel and delivered via the handshake, never awaited before opening (popup blockers otherwise regress the happy path).
+- **Origin pinning for the handshake only.** The launch origin is derived from `session.redirect_uri ?? REDIRECT_URL` (the same source the authorize `redirect_uri` uses today, `AuthorizeButton.tsx:36-38`, `src/constants/urls.ts:1`), so it is known per session — incoming `oauth_launch_ready` is validated with `event.source === child && event.origin === launchOrigin`, and the outgoing grant is posted with that explicit `targetOrigin`. The legacy `oauth_complete` path keeps its documented no-origin-check decision (white-label domains; see `thoughts/shared/plans/2026-06-19-GH-9546-drop-client-nonce-storage.md` § What We're NOT Doing).
+- **Grant never in any URL** — security-load-bearing; it travels only over the live opener `postMessage` handshake. Only non-secret correlation data (e.g. `service_id`) may appear in the launch URL.
+- **Test pattern**: `@testing-library/react` + `act()` + spied `window.open`/`window.fetch` + dispatched `MessageEvent` + jest fake timers for the poll/timeout branches; mock setup from `test/mock.ts` (based on: `test/authorize-button.test.tsx`, `test/connection-actions.test.tsx`).
+- **Types**: new `src/types/OAuthGrantHandoff.ts`; `src/types/OAuthCsrf.ts` untouched (legacy wire format stays).
+- **SWR refresh**: revalidating `mutate(detailUrl)` + `mutate('/vault/connections')` on success — unchanged from today (`AuthorizeButton.tsx:164-170`, `connectionActions.ts:151-157`).
+
+---
+
+## Overview
+
+Invert the confirm-token handoff direction for OAuth popups. Instead of the popup posting the `confirm_token` **backwards** to the widget after completion (dies when COOP severs `window.opener`), the widget hands a single-use, session-bound **grant forwards at open time** — over the opener link that is alive by construction because the popup's first page is vault's COOP-free `oauth/launch` — and the popup **self-confirms in-tab** at the callback (grant + `confirm_token`). Nothing travels popup → widget anymore, so iframe nesting, COOP, and storage partitioning become irrelevant. The widget detects completion by polling the connection state after the popup closes, and surfaces an actionable error instead of today's silent fake success. The legacy opener `postMessage` → JWT `/confirm` path stays fully armed as a fallback, making the rollout purely additive.
+
+## Current State Analysis
+
+Two structurally-duplicated popup flows exist:
+
+- **First-time authorize** — `src/components/AuthorizeButton.tsx:57-195` (`authorizeConnection`, rendered from `ConnectionDetails.tsx:473`).
+- **Re-authorize / disconnect** — `src/utils/connectionActions.ts:36-182` (`useConnectionActions().handleRedirect`, called from `TopBar.tsx:239-244`, `ButtonLayoutMenu.tsx:98-105`, `:286-293` for authorize and `TopBar.tsx:327`, `ButtonLayoutMenu.tsx:351-354` for revoke).
+
+Shared mechanics today:
+
+1. Authorize URL = `${connection.authorize_url}&redirect_uri=${session?.redirect_uri ?? REDIRECT_URL}` plus a stateless `&nonce=` param (`generateNonce`, `src/utils/oauthCsrf.ts:22-24`) — the nonce is unify's opt-in trigger for the confirm flow, never verified anywhere.
+2. `window.open(url, '_blank', 'location=no,height=750,width=550,...')` (`AuthorizeButton.tsx:176-180`, `connectionActions.ts:163-167`).
+3. A `message` listener filters on `data.type` and `data.serviceId` (no origin check, no nonce check) and POSTs `{ confirm_token }` to unify via `callConfirmEndpoint` (`src/utils/oauthCsrf.ts:26-56`) with JWT-derived headers from `useConnections` (`src/utils/useConnections.tsx:90-99`).
+4. A 500 ms `child.closed` poller with a 1000 ms grace period refetches the connection on close (`AuthorizeButton.tsx:182-193`, `connectionActions.ts:169-180`) — **it never calls `/confirm` and treats popup-close as success**, which is exactly the silent strand when COOP has severed the opener and the `confirm_token` was dropped in vault's callback.
+
+**The failure** (see `thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md` § 2): any COOP `same-origin` page in the popup's navigation chain moves it to a new browsing-context group, `window.opener` becomes `null` in vault's callback, the token is dropped, `/confirm` never fires, the connection sticks at `pending_confirmation`, and no `vault.connection.callable` webhook is emitted. Deterministic per configuration; no backwards in-browser channel survives (opener, BroadcastChannel, localStorage, relay iframes all die on COOP or storage partitioning — see `thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md` § Options already declined).
+
+Baseline note: the `fix_csrf_3` branch already contains the landed 2026-06-19 drop-client-nonce-storage refactor (stateless `generateNonce`, zero `sessionStorage` usage in `src/`). This plan builds on that state.
+
+## Cross-Repo Contract (assumed — coordination required)
+
+vault-core is one of three legs. This plan implements only the vault-core leg and **assumes** the following contracts; if the other repos land different names/shapes, update the constants/types in Phase 1 before wiring:
+
+**unify** (must deploy first):
+- `POST {connectionsUrl}/{unified_api}/{service_id}/grant` with the standard JWT headers → `{ status_code, status, data: { grant: string, expires_in: number } }`. The grant is single-use, short-TTL, bound to app+consumer+service+api and to the minting session (liveness checked at redemption). A 404/4xx/5xx from this endpoint means "grant flow unavailable" and must trigger the legacy fallback, not an error.
+- `POST .../confirm` additionally accepts an **unauthenticated** body `{ confirm_token, grant }` (in-tab self-confirm from vault's callback). The existing JWT + `{ confirm_token }` form stays (legacy fallback). No server-side grant parking keyed to OAuth state — that degrades to auto-confirm.
+
+**vault** (must deploy before vault-core release; see memory: vault-core depends on vault for callback handling):
+- New `GET /oauth/launch` page, served **without COOP**, that: posts `{ type: 'oauth_launch_ready' }` to `window.opener` (repeating every ~250 ms until answered), refuses loudly if `window.opener` is null or a sessionStorage write-read probe fails (anti-phishing: a handed-out launch link goes nowhere, and it fails before any consent), then on receiving `oauth_launch_start` stores the grant in tab sessionStorage and navigates the tab to the provided authorize URL.
+- `oauth/callback` self-confirms in-tab (reads + removes the grant from sessionStorage, POSTs `{ confirm_token, grant }`), falling back to the legacy opener `postMessage` when no grant is present or the self-confirm fails, then closes. Fallback ladder: sessionStorage self-confirm → legacy opener postMessage → loud error.
+
+The `postMessage` protocol types (Phase 1) are the single source of truth vault-core exports for its side of the wire.
+
+## Desired End State
+
+- Clicking authorize/re-authorize opens `{launchOrigin}/oauth/launch?service_id=...` synchronously and mints a grant in parallel; after the `ready` handshake the grant + legacy authorize URL are posted into the popup with an explicit `targetOrigin`.
+- If the grant mint fails **or** no `ready` arrives within the handshake timeout (old/self-hosted vault without the launch page), the widget navigates the already-open popup to the legacy authorize URL and the flow proceeds exactly as today.
+- The legacy `oauth_complete`/`oauth_error` listener stays armed in both modes (it is also the popup-side fallback when the in-tab self-confirm fails).
+- On popup close without a completed legacy confirm, the widget polls the connection detail endpoint until `state === 'callable'` (success: mutate + `onConnectionChange`, no toast) or a poll budget elapses (actionable error toast — never a silent fake success).
+- Revoke/disconnect popups are untouched (no mint, no handshake, no poll).
+- `yarn test --no-watch`, `tsdx build`, `tsdx lint` all green; grep confirms the grant never appears in any URL construction.
+
+**Verify:** `yarn test --no-watch`; `tsdx build`; `tsdx lint`; manual run of the example app happy path + a forced-timeout fallback (point `redirect_uri` at an origin with no launch page).
+
+## What We're NOT Doing
+
+- **Not** implementing the unify leg (grant mint/redeem endpoints) or the vault leg (`oauth/launch` page, callback self-confirm) — separate repos, separate plans; contracts pinned above.
+- **Not** removing the legacy `oauth_complete` postMessage → JWT `/confirm` path — it is the fallback ladder's second rung and stays indefinitely for older vault deployments.
+- **Not** removing the `&nonce=` param — it remains unify's opt-in trigger for minting the `confirm_token`, which the new flow still needs (the callback self-confirms with it).
+- **Not** adding an `event.origin` check to the **legacy** `oauth_complete` listener (unchanged decision: no fixed origin under white-label domains). The pinned-origin check applies only to the new launch handshake, whose origin is known by construction.
+- **Not** handling popup-blocked or custom `redirect_uri` hardening — separate, pre-existing scope (unify plan Phases 1–2 per the sequence-diagrams doc).
+- **Not** touching `client_credentials`/`password` grant paths, consent screens, or `pending_confirmation` UI states.
+- **Not** deduplicating `AuthorizeButton` and `connectionActions` into one flow implementation beyond what the shared utils naturally absorb — a full merge is a separate refactor.
+
+## Implementation Approach
+
+All genuinely new logic lands as pure, independently-testable functions in `src/utils/oauthGrantHandoff.ts` (Component A), so the two duplicated flow sites only gain thin wiring (Component B). TDD red-green per component:
+
+1. Types + constants (domain, no tests).
+2. RED: unit tests for the three utils (`mintGrant`, `runLaunchHandshake`, `pollForCallable`).
+3. GREEN: implement the utils.
+4. RED: integration tests for both flow sites (handshake happy path, both fallback triggers, poll success/timeout, revoke untouched, legacy behaviors preserved).
+5. GREEN: wire `AuthorizeButton` + `connectionActions` (+ call-site signature updates in `TopBar`/`ButtonLayoutMenu`).
+6. Verify full suite.
+7. Refactor/cleanup.
+
+Key runtime shape (intent, not code): on click — arm listeners, `window.open(launchUrl)` **synchronously**, fire `mintGrant` in parallel; `runLaunchHandshake` resolves `'handoff'` (ready received + grant delivered) or `'legacy'` (mint failed or ready timeout → it navigates `child.location.href` to the legacy authorize URL); on `child.closed` and not `completed`, keep today's 1000 ms grace, then `pollForCallable`; poll outcome drives mutate/`onConnectionChange` vs. an actionable error toast.
+
+**Edge cases handled by design** (worth keeping in review view):
+- *Grant delivered but user abandons at the provider*: grant expires server-side (TTL); popup close → poll → timeout → accurate "not completed" toast.
+- *In-tab self-confirm fails in the callback (expired/used grant)*: vault falls back to legacy opener postMessage; the widget's still-armed legacy listener confirms via JWT. The `completed` flag prevents the poller from double-reporting.
+- *Unify grant endpoint disabled/rolled back after release*: mint returns non-2xx → automatic legacy fallback per click; no stuck state.
+- *Re-authorize of an already-`callable` connection*: the poll sees `callable` immediately and reports success — degrades to today's silent-refetch behavior, no regression.
+- *User closes popup deliberately mid-consent*: poll timeout → informative toast; today this is a silent refetch, so the only change is honesty.
+
+---
+
+## Phase 1: Protocol Types + Constants (domain)
+
+### Overview
+
+Pin the wire contract and tunables. No behavior change, no tests required (types + constants only).
+
+### Session Startup Protocol
+1. Verify working directory: `pwd`
+2. Read progress JSON: `thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json`
+3. Confirm current phase matches JSON `current_phase`
+
+### Changes Required:
+
+#### 1. `src/types/OAuthGrantHandoff.ts` (new)
+- `LaunchReadyMessage` — `{ type: 'oauth_launch_ready' }` (popup → widget).
+- `LaunchStartMessage` — `{ type: 'oauth_launch_start'; grant: string; authorizeUrl: string }` (widget → popup; posted with explicit `targetOrigin`).
+- `GrantResponse` — `{ status_code: number; status: string; data: { grant: string; expires_in: number } }` (mirrors `ConfirmResponse` shape, `src/types/OAuthCsrf.ts:20-26`).
+- `HandshakeOutcome` — `'handoff' | 'legacy'`; `PollOutcome` — `'callable' | 'timeout'`.
+- Doc comment: grant is single-use, session-bound, never URL-carried; this file is the vault-core side of the vault `oauth/launch` contract.
+
+#### 2. `src/constants/urls.ts`
+- Add `OAUTH_LAUNCH_PATH = '/oauth/launch'`.
+
+#### 3. `src/constants/oauthGrantHandoff.ts` (new)
+- `LAUNCH_READY_TIMEOUT_MS = 3000` (fallback trigger for launch-page-less vaults), `CALLABLE_POLL_INTERVAL_MS = 1000`, `CALLABLE_POLL_BUDGET_MS = 15000`. Short comments on why each exists.
+
+### Success Criteria:
+
+#### Automated Verification:
+- `tsdx build` and `tsdx lint` pass; `yarn test --no-watch` still green (nothing imports the new files yet).
+
+#### Manual Verification:
+- Type/constant names match the Cross-Repo Contract section verbatim.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 1: grant-handoff protocol types and constants"` (+ `Co-Authored-By: Claude <noreply@anthropic.com>`)
+2. Update progress JSON: phase 1 → "complete", `current_phase` → 2.
+3. `git status` clean.
+
+---
+
+## Phase 2: Unit Tests for Grant-Handoff Utils (TDD - RED)
+
+### Overview
+
+Author `test/oauth-grant-handoff.test.ts` against the not-yet-existing `src/utils/oauthGrantHandoff.ts`. All tests fail (missing module) until Phase 3. One named test per branch/error path of the paired GREEN phase:
+
+### Changes Required:
+
+#### 1. `test/oauth-grant-handoff.test.ts` (new)
+
+**`describe('mintGrant')`** (spied `window.fetch`; params `{ unifiedApi, serviceId, connectionsUrl, headers }` like `callConfirmEndpoint`):
+- `POSTs to {connectionsUrl}/{unifiedApi}/{serviceId}/grant with the provided headers and returns the grant string on 2xx`
+- `returns null on non-2xx response (grant flow unavailable → caller falls back to legacy)`
+- `returns null when fetch rejects (network error) instead of throwing`
+
+**`describe('deriveLaunchUrl')`**:
+- `builds {origin(redirect_uri)}{OAUTH_LAUNCH_PATH}?service_id=... from a session redirect_uri`
+- `falls back to the REDIRECT_URL origin when session has no redirect_uri`
+- `never includes a grant parameter regardless of inputs` (guards the invariant at the only URL-construction point)
+
+**`describe('runLaunchHandshake')`** (stub `child` window object with `postMessage` spy + settable `location.href`; jest fake timers; params include `child`, `launchOrigin`, `legacyAuthorizeUrl`, and a `grantPromise`):
+- `posts oauth_launch_start with the grant and legacy authorize URL to the child with explicit targetOrigin after a valid ready message, and resolves 'handoff'`
+- `ignores a ready message whose event.source is not the opened child`
+- `ignores a ready message whose event.origin differs from the launch origin`
+- `navigates the child to the legacy authorize URL and resolves 'legacy' when no ready arrives within LAUNCH_READY_TIMEOUT_MS`
+- `navigates the child to the legacy authorize URL and resolves 'legacy' when the grant promise resolves null (mint failed)`
+- `removes its message listener after resolving (both outcomes)`
+
+**`describe('pollForCallable')`** (spied `window.fetch` returning connection detail payloads; fake timers; params `{ detailUrl, headers }`):
+- `resolves 'callable' as soon as a poll returns a connection with state 'callable'`
+- `resolves 'timeout' when the poll budget elapses while state stays 'pending_confirmation'`
+- `keeps polling through a failed fetch (transient error) rather than rejecting`
+- `stops polling immediately when the returned cancel function is invoked`
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch test/oauth-grant-handoff` fails only with "cannot find module" / missing exports; all other suites unaffected.
+
+#### Manual Verification:
+- Every branch listed in Phase 3's implementation notes has exactly one named test above.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 2: unit tests for grant-handoff utils (TDD - RED)"` (+ `Co-Authored-By`).
+2. Progress JSON: phase 2 → "complete", `current_phase` → 3.
+3. `git status` clean.
+
+---
+
+## Phase 3: Implement Grant-Handoff Utils (TDD - GREEN)
+
+### Overview
+
+Create `src/utils/oauthGrantHandoff.ts` making Phase 2 green. Pure functions, no React context access (mirrors `oauthCsrf.ts`).
+
+### Changes Required:
+
+#### 1. `src/utils/oauthGrantHandoff.ts` (new)
+- `mintGrant(params)` — `fetch` POST like `callConfirmEndpoint` (`src/utils/oauthCsrf.ts:26-56`) but returns `string | null`; any non-2xx or thrown error → `null` (fallback signal, never a throw — a failed mint must degrade, not break, the click).
+- `deriveLaunchUrl(session, serviceId)` — `new URL(session?.redirect_uri ?? REDIRECT_URL).origin + OAUTH_LAUNCH_PATH` + `?service_id=` (non-secret correlation only). Also export `deriveLaunchOrigin` (or return both) for the handshake's origin pin.
+- `runLaunchHandshake(params): Promise<HandshakeOutcome>` — arms its own `message` listener; on `oauth_launch_ready` with `event.source === child && event.origin === launchOrigin`, awaits `grantPromise`; grant present → `child.postMessage({ type: 'oauth_launch_start', grant, authorizeUrl }, launchOrigin)` → `'handoff'`; grant `null` or `LAUNCH_READY_TIMEOUT_MS` elapsed → `child.location.href = legacyAuthorizeUrl` → `'legacy'`. Always removes its listener and clears its timer on resolve.
+- `pollForCallable(params): { promise: Promise<PollOutcome>; cancel: () => void }` — `setInterval` at `CALLABLE_POLL_INTERVAL_MS` fetching `detailUrl` with `headers`; `data.state === 'callable'` → `'callable'`; budget `CALLABLE_POLL_BUDGET_MS` exhausted → `'timeout'`; fetch errors swallowed (keep polling); `cancel()` clears everything.
+- Module doc comment linking the two research docs and stating the invariants: grant never in a URL; handshake is the only delivery channel; legacy path remains as fallback.
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch` — full suite green (Phase 2 tests pass; nothing else touched).
+- `tsdx build`, `tsdx lint` pass.
+- `grep -rn "grant" src/ | grep -i "searchParams\|\?grant\|&grant"` returns nothing (no URL carries a grant).
+
+#### Manual Verification:
+- Confirm `runLaunchHandshake` performs no `window.open` itself — opening stays synchronous at the call sites.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 3: grant-handoff utils (TDD - GREEN)"` (+ `Co-Authored-By`).
+2. Progress JSON: phase 3 → "complete", `current_phase` → 4.
+3. `git status` clean.
+
+---
+
+## Phase 4: Integration Tests for Both Flow Sites (TDD - RED)
+
+### Overview
+
+Extend `test/authorize-button.test.tsx` and `test/connection-actions.test.tsx` to the new flow. The `window.open` spy must return a stub child (`postMessage` spy, settable `location.href`, mutable `closed`) — extend the existing spy setup. These fail until Phase 5 wires the components. One named test per new branch, mirrored across both files unless noted:
+
+### Changes Required:
+
+#### 1. `test/authorize-button.test.tsx`
+- `opens the popup to the launch URL synchronously on click, before the grant mint resolves` (assert `window.open` called with `{launchOrigin}/oauth/launch?service_id=...` and standard window features while the mint fetch is still pending)
+- `still mints the grant with a POST to .../grant carrying the JWT headers`
+- `on oauth_launch_ready from the child at the launch origin: posts oauth_launch_start with grant + legacy authorize URL (containing &nonce=) and explicit targetOrigin`
+- `when the grant mint returns non-2xx: navigates the popup to the legacy authorize URL and the legacy oauth_complete → /confirm path still works end-to-end`
+- `when no oauth_launch_ready arrives within LAUNCH_READY_TIMEOUT_MS: navigates the popup to the legacy authorize URL` (fake timers)
+- `legacy oauth_complete received after a completed handoff handshake: still POSTs /confirm exactly once (popup-side fallback; no double confirm with the poller)`
+- `on popup close after handoff without oauth_complete: polls the connection detail URL and, on state=callable, mutates and fires onConnectionChange without an error toast`
+- `on popup close with the connection stuck pending_confirmation: shows an actionable error toast after the poll budget, never a silent success`
+- `on oauth_error: toasts, does not confirm, and does not start the callable poll`
+- Preserved-behavior updates: the existing `oauth_complete → /confirm`, foreign-`serviceId`, grace-period, and no-double-confirm tests are updated only where the opened URL changed (launch URL instead of authorize URL) — their assertions about `/confirm` semantics stay identical.
+
+#### 2. `test/connection-actions.test.tsx`
+- Mirror all of the above for `handleRedirect` (re-authorize path), plus:
+- `revoke/disconnect: opens the revoke URL directly — no grant mint, no handshake listener, no callable poll` (the new options are absent at revoke call sites)
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch` — the new specs fail for the expected reason (components still open the authorize URL directly); Phase 2/3 suites stay green.
+
+#### Manual Verification:
+- Each edge case in Implementation Approach § Edge cases maps to at least one named test.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 4: integration tests for grant handoff flows (TDD - RED)"` (+ `Co-Authored-By`).
+2. Progress JSON: phase 4 → "complete", `current_phase` → 5.
+3. `git status` clean.
+
+---
+
+## Phase 5: Wire Components (TDD - GREEN)
+
+### Overview
+
+Wire the utils into both flow sites and update the two re-authorize call sites. Revoke paths untouched.
+
+### Changes Required:
+
+#### 1. `src/components/AuthorizeButton.tsx`
+- Import the three utils + constants; keep everything about the legacy listener (`:122-173`) intact.
+- In `authorizeConnection`: build the legacy authorize URL exactly as today (nonce included, `:104-107`); `window.open(deriveLaunchUrl(...))` synchronously (`:176-180` window-features string unchanged); start `mintGrant` in parallel (do not await before opening); run `runLaunchHandshake` with the child, pinned launch origin, legacy URL, and grant promise.
+- Replace the body of the close-poller's post-grace branch (`:182-193`): instead of blind `handleChildWindowClose()`, if not `completed`, run `pollForCallable` against the existing detail URL/headers (both already in scope for `callConfirmEndpoint`, `:144-150`); `'callable'` → existing mutate + `onConnectionChange` path; `'timeout'` → error toast ("Authorization was not completed — please retry"); either way `cleanup()`.
+- `cleanup()` additionally cancels an in-flight poll and the handshake listener/timer.
+- `completed` flag set by the legacy `oauth_complete` confirm as today — the poller checks it before starting (prevents double reporting).
+
+#### 2. `src/utils/connectionActions.ts`
+- `handleRedirect(url, onConnectionChange)` gains an optional third param, e.g. `grantHandoff?: { unifiedApi: string; serviceId: string }`. Absent (revoke call sites) → today's behavior byte-for-byte. Present → same open/mint/handshake/poll sequence as `AuthorizeButton` (`connectionActions.ts:163-180` region).
+
+#### 3. `src/components/TopBar.tsx` (`:240-244`) and `src/components/ButtonLayoutMenu.tsx` (`:98-105`, `:286-293`)
+- Pass the new `grantHandoff` context at the re-authorize call sites (both have the connection in scope). Revoke call sites (`TopBar.tsx:327`, `ButtonLayoutMenu.tsx:351-354`) unchanged.
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch` — full suite green.
+- `tsdx build`, `tsdx lint` pass.
+
+#### Manual Verification:
+- Example app: authorize an OAuth connector — popup opens on the launch URL; with no launch page deployed the popup lands on the legacy authorize URL within ~3 s and the flow completes as before.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 5: wire grant handoff into authorize flows (TDD - GREEN) Ref #9546"` (+ `Co-Authored-By`).
+2. Progress JSON: phase 5 → "complete", `current_phase` → 6.
+3. `git status` clean.
+
+---
+
+## Phase 6: Verify Full Suite (TDD - GREEN verification)
+
+### Overview
+Whole-suite verification; fix any fallout.
+
+### Changes Required:
+- No planned changes. Run: `yarn test --no-watch`, `tsdx build`, `tsdx lint`.
+- Invariant greps: grant never URL-carried (Phase 3 grep); `grep -rn "sessionStorage" src/` still returns nothing (the widget side never touches storage — only vault's launch/callback pages do, in their repo).
+
+### Success Criteria:
+
+#### Automated Verification:
+- All three commands green; both greps clean.
+
+#### Manual Verification:
+- Manual matrix in the example app: (a) happy path with a stubbed launch page, (b) mint-failure fallback, (c) ready-timeout fallback, (d) popup closed mid-flow → actionable toast after poll budget.
+
+### Session Completion
+1. If fixes were needed: commit `git add -A && git commit -m "Phase 6: verification fixes"`; else no commit.
+2. Progress JSON: phase 6 → "complete", `current_phase` → 7.
+3. `git status` clean.
+
+---
+
+## Phase 7: Cleanup (TDD - REFACTOR)
+
+### Overview
+Tidy while green; reduce the duplication the wiring added.
+
+### Changes Required:
+- Extract any now-identical open/mint/handshake/poll sequence shared by `AuthorizeButton.tsx` and `connectionActions.ts` into a helper in `oauthGrantHandoff.ts` **if** it falls out naturally — do not force a full flow merge (out of scope).
+- Ensure module doc comments state the fallback ladder and the deployment-order dependency (unify → vault → vault-core release).
+- Confirm no dead imports/constants; toast copy reviewed for actionability.
+
+### Success Criteria:
+
+#### Automated Verification:
+- `yarn test --no-watch`, `tsdx build`, `tsdx lint` all green.
+
+#### Manual Verification:
+- Diff review: no behavioral change vs. Phase 5.
+
+### Session Completion
+1. Commit: `git add -A && git commit -m "Phase 7: cleanup after grant handoff wiring (TDD - REFACTOR)"` (+ `Co-Authored-By`).
+2. Progress JSON: phase 7 → "complete".
+3. `git status` clean.
+
+---
+
+## Testing Strategy
+
+**Follow TDD (red-green-refactor).** Component A (utils) and Component B (flow wiring) each get a paired RED/GREEN cycle; every new `if`/timeout/error branch has a named test (enumerated in Phases 2 and 4).
+
+### Unit (`test/oauth-grant-handoff.test.ts`)
+`mintGrant` (2xx / non-2xx / rejection), `deriveLaunchUrl` (session-derived / fallback origin / grant-free invariant), `runLaunchHandshake` (handoff, wrong-source, wrong-origin, ready-timeout, null-grant, listener teardown), `pollForCallable` (callable, timeout, transient fetch error, cancel).
+
+### Integration (`test/authorize-button.test.tsx`, `test/connection-actions.test.tsx`)
+Synchronous launch-URL open; parallel mint; grant delivery with pinned targetOrigin; both legacy fallback triggers keep the full legacy confirm working; popup-side fallback confirm after handoff without double-confirm; poll success (no toast) and poll timeout (actionable toast); `oauth_error` skips confirm and poll; revoke path completely untouched; preserved legacy suite (foreign serviceId, grace period, no double confirm) updated only for the changed opened-URL assertion.
+
+### Manual
+1. `example/storage-roundtrip/` remains the design's mechanism harness (GO recorded); the example app is the wiring harness.
+2. Full matrix per Phase 6: happy path, mint-fail fallback, timeout fallback, abandoned-flow toast.
+3. Cross-browser spot check once vault's launch page exists: Chrome, Firefox, Safari (note Safari cannot load literal-IPv6 URLs — use `127.0.0.1` in local harnesses).
+
+## Migration & Rollout Notes
+
+- **Deployment order is load-bearing**: unify (grant endpoints) → vault (launch page + callback self-confirm) → vault-core release. Shipping vault-core first is safe only because of the ready-timeout fallback — every click would pay the ~3 s timeout, so don't.
+- **Purely additive**: older vault deployments (no launch page) and unify rollback (grant endpoint gone) both degrade automatically to today's flow per click; no stored client state, no migration.
+- **Security invariants (non-negotiable in review)**: grant never in any URL; launcher never proceeds without a completed opener handshake; no server-side grant parking keyed to OAuth state; `window.open` stays synchronous in the click handler; fallback ladder is sessionStorage self-confirm → legacy opener postMessage → loud error.
+
+## References
+
+- Problem & requirements: `thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md`
+- Design + sequence diagrams: `thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md`
+- Go/no-go evidence: `example/storage-roundtrip/README.md` (GO on Blink, Gecko, WebKit)
+- Failure repro: `example/opener-severed-confirm/`
+- Baseline plan (landed on this branch): `thoughts/shared/plans/2026-06-19-GH-9546-drop-client-nonce-storage.md`
+- Current flow: `src/components/AuthorizeButton.tsx:57-195`, `src/utils/connectionActions.ts:36-182`, `src/utils/oauthCsrf.ts:22-56`, `src/utils/useConnections.tsx:90-119`, `src/constants/urls.ts:1-2`

--- a/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
+++ b/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
@@ -1,6 +1,6 @@
 {
   "plan": "2026-07-17-oauth-confirm-grant-handoff.md",
-  "current_phase": 3,
+  "current_phase": 4,
   "total_phases": 7,
   "warnings": [
     "tsdx lint is broken environment-wide (pre-existing eslint-plugin-prettier resolution failure under Node 24, reproduced on a clean tree); Prettier --check on touched files used as substitute",
@@ -9,8 +9,8 @@
   "phases": [
     {"id": 1, "name": "Protocol Types + Constants (domain)", "status": "complete"},
     {"id": 2, "name": "Unit Tests for Grant-Handoff Utils (TDD - RED)", "status": "complete"},
-    {"id": 3, "name": "Implement Grant-Handoff Utils (TDD - GREEN)", "status": "in_progress"},
-    {"id": 4, "name": "Integration Tests for Both Flow Sites (TDD - RED)", "status": "pending"},
+    {"id": 3, "name": "Implement Grant-Handoff Utils (TDD - GREEN)", "status": "complete"},
+    {"id": 4, "name": "Integration Tests for Both Flow Sites (TDD - RED)", "status": "in_progress"},
     {"id": 5, "name": "Wire Components (TDD - GREEN)", "status": "pending"},
     {"id": 6, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "pending"},
     {"id": 7, "name": "Cleanup (TDD - REFACTOR)", "status": "pending"}

--- a/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
+++ b/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
@@ -1,14 +1,15 @@
 {
   "plan": "2026-07-17-oauth-confirm-grant-handoff.md",
-  "current_phase": 2,
+  "current_phase": 3,
   "total_phases": 7,
   "warnings": [
-    "tsdx lint is broken environment-wide (pre-existing eslint-plugin-prettier resolution failure under Node 24, reproduced on a clean tree); Prettier --check on touched files used as substitute"
+    "tsdx lint is broken environment-wide (pre-existing eslint-plugin-prettier resolution failure under Node 24, reproduced on a clean tree); Prettier --check on touched files used as substitute",
+    "no tracked .alan/symbols/ carve-out in this repo; reindex runs locally but shards are left untracked"
   ],
   "phases": [
     {"id": 1, "name": "Protocol Types + Constants (domain)", "status": "complete"},
-    {"id": 2, "name": "Unit Tests for Grant-Handoff Utils (TDD - RED)", "status": "in_progress"},
-    {"id": 3, "name": "Implement Grant-Handoff Utils (TDD - GREEN)", "status": "pending"},
+    {"id": 2, "name": "Unit Tests for Grant-Handoff Utils (TDD - RED)", "status": "complete"},
+    {"id": 3, "name": "Implement Grant-Handoff Utils (TDD - GREEN)", "status": "in_progress"},
     {"id": 4, "name": "Integration Tests for Both Flow Sites (TDD - RED)", "status": "pending"},
     {"id": 5, "name": "Wire Components (TDD - GREEN)", "status": "pending"},
     {"id": 6, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "pending"},

--- a/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
+++ b/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
@@ -1,6 +1,6 @@
 {
   "plan": "2026-07-17-oauth-confirm-grant-handoff.md",
-  "current_phase": 4,
+  "current_phase": 5,
   "total_phases": 7,
   "warnings": [
     "tsdx lint is broken environment-wide (pre-existing eslint-plugin-prettier resolution failure under Node 24, reproduced on a clean tree); Prettier --check on touched files used as substitute",
@@ -10,8 +10,8 @@
     {"id": 1, "name": "Protocol Types + Constants (domain)", "status": "complete"},
     {"id": 2, "name": "Unit Tests for Grant-Handoff Utils (TDD - RED)", "status": "complete"},
     {"id": 3, "name": "Implement Grant-Handoff Utils (TDD - GREEN)", "status": "complete"},
-    {"id": 4, "name": "Integration Tests for Both Flow Sites (TDD - RED)", "status": "in_progress"},
-    {"id": 5, "name": "Wire Components (TDD - GREEN)", "status": "pending"},
+    {"id": 4, "name": "Integration Tests for Both Flow Sites (TDD - RED)", "status": "complete"},
+    {"id": 5, "name": "Wire Components (TDD - GREEN)", "status": "in_progress"},
     {"id": 6, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "pending"},
     {"id": 7, "name": "Cleanup (TDD - REFACTOR)", "status": "pending"}
   ]

--- a/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
+++ b/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
@@ -1,0 +1,17 @@
+{
+  "plan": "2026-07-17-oauth-confirm-grant-handoff.md",
+  "current_phase": 2,
+  "total_phases": 7,
+  "warnings": [
+    "tsdx lint is broken environment-wide (pre-existing eslint-plugin-prettier resolution failure under Node 24, reproduced on a clean tree); Prettier --check on touched files used as substitute"
+  ],
+  "phases": [
+    {"id": 1, "name": "Protocol Types + Constants (domain)", "status": "complete"},
+    {"id": 2, "name": "Unit Tests for Grant-Handoff Utils (TDD - RED)", "status": "in_progress"},
+    {"id": 3, "name": "Implement Grant-Handoff Utils (TDD - GREEN)", "status": "pending"},
+    {"id": 4, "name": "Integration Tests for Both Flow Sites (TDD - RED)", "status": "pending"},
+    {"id": 5, "name": "Wire Components (TDD - GREEN)", "status": "pending"},
+    {"id": 6, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "pending"},
+    {"id": 7, "name": "Cleanup (TDD - REFACTOR)", "status": "pending"}
+  ]
+}

--- a/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
+++ b/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
@@ -1,6 +1,6 @@
 {
   "plan": "2026-07-17-oauth-confirm-grant-handoff.md",
-  "current_phase": 5,
+  "current_phase": 6,
   "total_phases": 7,
   "warnings": [
     "tsdx lint is broken environment-wide (pre-existing eslint-plugin-prettier resolution failure under Node 24, reproduced on a clean tree); Prettier --check on touched files used as substitute",
@@ -11,8 +11,8 @@
     {"id": 2, "name": "Unit Tests for Grant-Handoff Utils (TDD - RED)", "status": "complete"},
     {"id": 3, "name": "Implement Grant-Handoff Utils (TDD - GREEN)", "status": "complete"},
     {"id": 4, "name": "Integration Tests for Both Flow Sites (TDD - RED)", "status": "complete"},
-    {"id": 5, "name": "Wire Components (TDD - GREEN)", "status": "in_progress"},
-    {"id": 6, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "pending"},
+    {"id": 5, "name": "Wire Components (TDD - GREEN)", "status": "complete"},
+    {"id": 6, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "in_progress"},
     {"id": 7, "name": "Cleanup (TDD - REFACTOR)", "status": "pending"}
   ]
 }

--- a/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
+++ b/thoughts/shared/progress/2026-07-17-oauth-confirm-grant-handoff-status.json
@@ -1,6 +1,7 @@
 {
   "plan": "2026-07-17-oauth-confirm-grant-handoff.md",
-  "current_phase": 6,
+  "completed": true,
+  "current_phase": 7,
   "total_phases": 7,
   "warnings": [
     "tsdx lint is broken environment-wide (pre-existing eslint-plugin-prettier resolution failure under Node 24, reproduced on a clean tree); Prettier --check on touched files used as substitute",
@@ -12,7 +13,7 @@
     {"id": 3, "name": "Implement Grant-Handoff Utils (TDD - GREEN)", "status": "complete"},
     {"id": 4, "name": "Integration Tests for Both Flow Sites (TDD - RED)", "status": "complete"},
     {"id": 5, "name": "Wire Components (TDD - GREEN)", "status": "complete"},
-    {"id": 6, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "in_progress"},
-    {"id": 7, "name": "Cleanup (TDD - REFACTOR)", "status": "pending"}
+    {"id": 6, "name": "Verify Full Suite (TDD - GREEN verification)", "status": "complete"},
+    {"id": 7, "name": "Cleanup (TDD - REFACTOR)", "status": "complete"}
   ]
 }

--- a/thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md
+++ b/thoughts/shared/research/2026-07-14-oauth-confirm-iframe-context.md
@@ -1,0 +1,35 @@
+# OAuth confirm handoff — problem, requirements, rejected options
+
+**Date:** 2026-07-14
+
+## Problem
+
+Embedded Vault (`@apideck/react-vault`) requires a client-driven `POST /confirm` to move an OAuth connection from `authorized` → `callable`. After OAuth, vault's popup callback delivers the `confirm_token` to the widget only via `window.opener.postMessage`. When the widget is nested in cross-origin iframes (OCTA), `window.opener` is `null` (COOP / popup isolation), the token is dropped, `/confirm` never fires, and the connection is stuck at `pending_confirmation` with no `vault.connection.callable` webhook.
+
+Not random — deterministic per configuration (provider COOP behavior × embedded-or-not × browser storage partitioning). "Spotty" only across the population of accounts. For a given setup (e.g. OCTA) it fails 100%.
+
+## Requirements any fix must satisfy
+
+The confirm step is the CSRF gate. Removing or weakening it enables account-harvesting: a Vault user crafts an authorize URL bound to their own consumer, phishes a provider-account owner (who need not be a Vault user), and on the victim's consent the attacker's consumer gets connected to the victim's provider account.
+
+To prevent that, the confirming secret must be:
+
+1. **Minted post-completion** (after the victim authenticates) — so whoever crafted the initiation link can't know it up front.
+2. **Delivered only into the browsing context that initiated the flow**, and redeemable only with the matching session JWT — so a phisher who merely handed out a link never receives it.
+
+The current design meets both via the opener channel. That channel is exactly what nested cross-origin iframes destroy — so the security mechanism and the failure are the same object. No client-side rearrangement keeps both requirements and survives the iframe.
+
+### Additional constraints
+
+- No `event.origin` allowlists / no redirect-origin manipulation (vault + vault-core are customer-self-deployable).
+- Consent phishing itself (victim consents on the real provider) is the provider's consent-screen responsibility — out of scope; but the fix must not make the attack a one-click, no-token affair.
+
+## Options already declined
+
+| Option | Why declined |
+|---|---|
+| **Surface an error / retry on popup-close** (frontend hardening) | Workaround, not a fix — just tells the user it failed. Doesn't make nested-iframe work. |
+| **`window.opener` / relay-iframe / BroadcastChannel / localStorage** | All die on COOP (severed window handle) or storage partitioning (a vault-origin iframe under a customer top-level site is in a different storage partition than the top-level vault popup). No in-browser channel carries data from a top-level cross-site popup into a deeply-nested third-party iframe. |
+| **Session-scoped `POST /confirm-pending`** (confirm any pending state for the consumer, no token echo) | Reopens CSRF: degrades to "confirm whatever is pending," reintroducing connection injection. |
+| **Widget-minted nonce sent outbound, redeemed with JWT** | Violates requirement 1: a secret present at initiation is known to the link-crafter (the attacker), who can then confirm. |
+| **Server-side auto-confirm at unify callback** | Callback is unauthenticated, and the flow binds to the attacker's consumer in the phishing case — auto-confirm hands the attacker the victim's account with zero further steps. Strictly worse. |

--- a/thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md
+++ b/thoughts/shared/research/2026-07-16-oauth-confirm-handoff-sequence-diagrams.md
@@ -1,0 +1,156 @@
+# OAuth confirm handoff — current vs. proposed flow (sequence diagrams)
+
+**Date:** 2026-07-16
+**Related:**
+- Problem & security requirements: [`2026-07-14-oauth-confirm-iframe-context.md`](./2026-07-14-oauth-confirm-iframe-context.md)
+- Failure repro: [`example/opener-severed-confirm/`](../../../example/opener-severed-confirm/)
+- Design go/no-go experiment (GO on Blink, Gecko, WebKit): [`example/storage-roundtrip/`](../../../example/storage-roundtrip/)
+
+An embedded (vault-core) OAuth connection only becomes `callable` after a
+client-driven `POST /confirm` carrying the single-use `confirm_token`. The
+diagrams below show how that token travels today, exactly where it dies, and
+how the proposed design reroutes it.
+
+---
+
+## 1. Current behavior — happy path (opener intact)
+
+The `confirm_token` travels **backwards** out of the popup via
+`window.opener.postMessage`, and the widget (which holds the session JWT)
+redeems it.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Widget<br/>(vault-core, iframe in customer page,<br/>holds session JWT)
+    participant P as Popup tab
+    participant PR as Provider<br/>(e.g. Xero)
+    participant U as Unify API
+    participant CB as Vault oauth/callback<br/>(page in popup, no JWT)
+
+    W->>P: window.open(authorize URL)
+    P->>U: GET /vault/authorize
+    U-->>P: 302 → provider consent
+    P->>PR: user authenticates & consents
+    PR-->>P: 302 → unify callback (code)
+    P->>U: OAuth code exchange (CallbackConnectionUseCase)
+    U-->>P: 302 → vault /oauth/callback#nonce&confirm_token&service_id
+    Note over CB: confirm_token minted post-completion,<br/>delivered only into this tab
+    CB->>W: window.opener.postMessage(confirm_token) ✅ opener is alive
+    CB->>CB: window.close()
+    W->>U: POST /confirm (JWT + confirm_token)
+    U-->>W: connection → callable ✅ (+ vault.connection.callable webhook)
+```
+
+---
+
+## 2. Current behavior — the failure (opener severed by COOP)
+
+When any page in the popup's navigation chain (provider or callback) is served
+with `Cross-Origin-Opener-Policy: same-origin`, the browser moves the popup
+into a new browsing-context group and **`window.opener` becomes `null`**.
+Deterministic per configuration — for a nested-iframe embedder like OCTA it
+fails 100% of the time.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Widget<br/>(vault-core, iframe in customer page,<br/>holds session JWT)
+    participant P as Popup tab
+    participant PR as Provider<br/>(e.g. Xero)
+    participant U as Unify API
+    participant CB as Vault oauth/callback<br/>(page in popup, no JWT)
+
+    W->>P: window.open(authorize URL)
+    P->>U: GET /vault/authorize
+    U-->>P: 302 → provider consent
+    rect rgb(254, 226, 226)
+        P->>PR: user authenticates & consents
+        Note over P,PR: a page in this chain carries<br/>COOP: same-origin →<br/>browsing-context group swap →<br/>window.opener = null 💥
+    end
+    PR-->>P: 302 → unify callback (code)
+    P->>U: OAuth code exchange
+    U-->>P: 302 → vault /oauth/callback#nonce&confirm_token&service_id
+    rect rgb(254, 226, 226)
+        Note over CB: if (window.opener) → FALSE<br/>confirm_token silently DROPPED
+        CB->>CB: window.close()  ← token lost forever
+    end
+    W->>W: child.closed poller fires → re-fetch
+    Note over W: connection still authorized /<br/>pending_confirmation — but the UI<br/>treats popup-close as success 💥
+    Note over U: no /confirm ever arrives →<br/>stuck pending_confirmation,<br/>no callable webhook,<br/>confirm_token expires in 30 min
+```
+
+**Why no client-side patch fixes this as-is:** the callback page has no JWT
+(it cannot self-confirm), and every backwards channel from a top-level popup
+into a nested cross-origin iframe — opener, BroadcastChannel, localStorage,
+relay iframes — is destroyed by the same COOP severance or by storage
+partitioning. The opener channel is simultaneously the CSRF gate and the
+failure.
+
+---
+
+## 3. Proposed behavior — grant handed forward at open time
+
+Invert the direction: don't carry the secret backwards after completion —
+carry a delegation **forwards at open time**, when the opener link is
+guaranteed alive because the popup's first page (`oauth/launch`) is
+vault-origin and served **without COOP**. The popup then confirms itself
+in-tab; nothing ever travels popup → widget.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Widget<br/>(vault-core, iframe in customer page,<br/>holds session JWT)
+    participant L as Vault oauth/launch<br/>(popup page 1, vault origin, NO COOP)
+    participant PR as Provider<br/>(e.g. Xero)
+    participant U as Unify API
+    participant CB as Vault oauth/callback<br/>(popup page 3, vault origin)
+
+    W->>L: window.open(launch URL) — synchronous, in the click handler
+    W->>U: POST authorize-init (JWT) — in parallel
+    U-->>W: single-use grant<br/>(session-bound, short TTL,<br/>scoped to app+consumer+service+api)
+    rect rgb(220, 252, 231)
+        L->>W: postMessage("ready") — opener alive BY CONSTRUCTION
+        W->>L: postMessage(grant, vaultOrigin) — never via URL
+        L->>L: store grant in tab's vault-origin sessionStorage
+        Note over L: no opener or no storage?<br/>→ refuse loudly, BEFORE any consent
+    end
+    L->>U: navigate tab → GET /vault/authorize
+    U-->>L: 302 → provider consent
+    rect rgb(254, 249, 195)
+        L->>PR: user authenticates & consents
+        Note over L,PR: COOP may sever window.opener here —<br/>IRRELEVANT: nothing uses it anymore.<br/>sessionStorage survives the context-group<br/>swap (verified: Blink, Gecko, WebKit)
+    end
+    PR-->>CB: 302 → unify callback → vault /oauth/callback#confirm_token
+    rect rgb(220, 252, 231)
+        CB->>CB: read grant from sessionStorage (single-use)
+        CB->>U: POST /confirm (grant + confirm_token) — in-tab self-confirm
+        U-->>CB: validates single-use, context binding,<br/>session liveness → callable ✅ (+ webhook)
+        CB->>CB: window.close()
+    end
+    W->>U: poll connection state (JWT) after popup close
+    U-->>W: callable ✅ — or an actionable error if not,<br/>never a silent fake success
+```
+
+### Why the CSRF gate still holds
+
+Confirmation requires two halves that only ever coexist in the legitimate tab:
+
+| Half | Minted | Reachable by a phisher who hands out a link? |
+|---|---|---|
+| `confirm_token` | post-completion, at the callback | No — it never leaves the completer's tab (today it crosses a `postMessage('*')` hop; the proposal removes even that) |
+| grant | at initiation, from the widget's JWT | No — it enters a popup **only** through a live opener handshake at open time; no URL ever carries it |
+
+A victim who clicks a phished authorize URL produces a token with no grant
+beside it; the attacker holds a grant but never sees a token. The legacy
+opener path stays as a fallback (older vault-core versions, storage-blocked
+browsers), so the rollout is purely additive.
+
+### Failure modes, before vs. after
+
+| Failure mode | Current | Proposed |
+|---|---|---|
+| COOP on provider/callback chain (the OCTA bug) | silent strand | **fixed** — no opener dependency after open time |
+| Nested cross-origin iframes / storage partitioning | silent strand | **fixed** — nothing travels back into the iframe |
+| Customer's own top-level page sets COOP | silent strand | loud, pre-consent, customer-fixable error |
+| Popup blocked / custom `redirect_uri` | broken | unchanged — separate hardening (existing plan Phases 1–2) |


### PR DESCRIPTION
## Problem

Connections get stuck at `pending_confirmation` when a COOP `same-origin` page anywhere in the OAuth popup's navigation chain severs `window.opener` — deterministic for nested-iframe embedders (e.g. OCTA). The popup's `oauth_complete` postMessage never reaches the widget, `/confirm` never fires, and the widget's close-poller silently treats popup close as success.

## Solution: forward grant handoff

Invert the handoff direction. Instead of the popup posting the `confirm_token` backwards after completion, the widget hands a single-use, session-bound **grant forwards at open time** over the opener link (alive by construction, because the popup's first page is vault's COOP-free `oauth/launch`), and the popup self-confirms in-tab at the callback. Nothing travels popup → widget anymore, so iframe nesting, COOP, and storage partitioning become irrelevant.

- Popup opens on `{launchOrigin}/oauth/launch?service_id=...` **synchronously** in the click handler (popup-blocker safe); the grant is minted in parallel (`POST .../grant`) and delivered via an origin-pinned `oauth_launch_ready` / `oauth_launch_start` postMessage handshake — the grant never appears in any URL.
- **Fallback ladder** (purely additive rollout): mint failure or no `ready` within 3 s (older/self-hosted vault without the launch page) → the popup is navigated to the legacy authorize URL and today's flow proceeds unchanged. The legacy `oauth_complete` → JWT `/confirm` listener stays armed in both modes.
- On popup close without a completed confirm, the widget now **polls the connection detail endpoint** (1 s interval, 15 s budget): `callable` → mutate + `onConnectionChange`; timeout → actionable "Authorization was not completed" toast instead of today's silent fake success.
- Revoke/disconnect popups are byte-for-byte untouched (guarded by a test).

## Changes

- New pure utils `src/utils/oauthGrantHandoff.ts` (`mintGrant`, `deriveLaunchUrl`, `runLaunchHandshake`, `pollForCallable` + shared popup helpers), types `src/types/OAuthGrantHandoff.ts`, constants `src/constants/oauthGrantHandoff.ts`.
- Wired into both flow sites: `AuthorizeButton` and `useConnectionActions().handleRedirect` (new optional `grantHandoff` param; absent at revoke call sites), call sites updated in `TopBar` / `ButtonLayoutMenu`.
- `Vault.tsx` now uses a per-mount `SWRConfig` Map cache — fixes stale connection state leaking across Vault mounts (e.g. a cached `callable` detail hiding the Authorize button on remount).
- Tests: new unit suite `test/oauth-grant-handoff.test.ts` + 19 integration tests across `authorize-button` / `connection-actions`; suite grew 66 → 101, all green.
- Also included on this branch: the `example/opener-severed-confirm/` failure repro and `example/storage-roundtrip/` go/no-go harness (GO on Blink, Gecko, WebKit), plus the research docs and implementation plan under `thoughts/`.

## Cross-repo dependencies (load-bearing deploy order)

unify (grant mint/redeem endpoints) → vault (`oauth/launch` page + callback self-confirm) → **this release**. Shipping vault-core first is safe but pays the 3 s handshake timeout on every click — don't. Contracts are pinned in the plan's Cross-Repo Contract section (`thoughts/shared/plans/2026-07-17-oauth-confirm-grant-handoff.md`).

## Security invariants (please hold the review to these)

- Grant never in any URL — delivered only over the live opener postMessage handshake, with pinned `targetOrigin`.
- `window.open` stays synchronous in the click handler.
- The legacy `oauth_complete` listener keeps its documented no-origin-check decision (white-label domains); the pinned-origin check applies only to the new launch handshake.

## Verification

- `yarn test --no-watch`: 12 suites, 101 tests green; `tsdx build` green.
- Invariant greps clean: no `grant` in any URL construction; no `sessionStorage` usage in `src/`.
- `tsdx lint` is currently broken environment-wide (pre-existing eslint-plugin-prettier resolution failure under Node 24); `prettier --check` passes on all touched files.
- Manual example-app matrix (happy path, mint-fail fallback, ready-timeout fallback, abandoned-flow toast) pending vault's `oauth/launch` page.

Ref #9546

🤖 Generated with [Claude Code](https://claude.com/claude-code)