### PR TITLE
feat: hide the attribution pill when the session claim says so (Ref #9854)

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -17,6 +17,7 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
   style?: CSSProperties;
   showAttribution?: boolean;
+  attribution?: { hidden?: boolean; hideable?: boolean };
   applicationId?: string;
 }
 
@@ -53,6 +54,7 @@ const Modal: any = ({
   onClose,
   isOpen = false,
   showAttribution,
+  attribution,
   applicationId,
   className = '',
   style = {},
@@ -159,8 +161,15 @@ const Modal: any = ({
                 {children}
               </div>
             </Transition.Child>
+            {/*
+              The prop and the claim are independent vetoes, mirroring
+              showConsumer x settings.hide_consumer_card in ModalContent: a
+              lower-plan customer passing showAttribution={false} still hides the
+              pill. Enforcing entitlement against the prop is a separate,
+              deliberate follow-up, not this change.
+            */}
             <Transition
-              show={isOpen && showAttribution}
+              show={isOpen && showAttribution && !attribution?.hidden}
               as={Fragment}
               enter="ease-out duration-300 delay-300"
               enterFrom="opacity-0 translate-y-4"

--- a/src/components/Vault.tsx
+++ b/src/components/Vault.tsx
@@ -186,6 +186,7 @@ export const Vault = forwardRef<HTMLElement, Props>(function Vault(
           isOpen={token && token?.length > 0 && isOpen}
           onClose={() => onCloseModal()}
           showAttribution={showAttribution}
+          attribution={session?.attribution}
           applicationId={session?.application_id}
         >
           <ToastProvider>

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -34,4 +34,14 @@ export interface Session {
   consumer_metadata?: SessionConsumerMetadata;
   jwt?: string;
   data_scopes?: { enabled?: boolean };
+  /**
+   * Server-derived, resolved at session-mint time.
+   * `hidden` is true only when the application has the setting on AND the
+   * account is entitled to it, so a plan downgrade re-enables attribution on
+   * the next session with no migration.
+   * `hideable` reports the entitlement itself, which is what distinguishes an
+   * authorised suppression from an unauthorised one.
+   * Absent on tokens minted without an account (e.g. management sessions).
+   */
+  attribution?: { hidden?: boolean; hideable?: boolean };
 }

--- a/test/attribution.test.tsx
+++ b/test/attribution.test.tsx
@@ -1,0 +1,82 @@
+import '@testing-library/jest-dom/extend-expect';
+import 'jest-location-mock';
+import 'whatwg-fetch';
+
+import * as React from 'react';
+
+import { fetchMock, setupIntersectionObserverMock } from './mock';
+
+import { NO_ADDED_CONNECTIONS_RESPONSE } from './responses/no-added-connections';
+import { Vault } from '../src/components/Vault';
+import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
+
+// jwt-decode does not verify signatures, so an unsigned token is enough to
+// drive the session the component reads.
+const tokenWithClaims = (claims: Record<string, unknown>) => {
+  const encode = (value: object) =>
+    Buffer.from(JSON.stringify(value)).toString('base64url');
+
+  return [
+    encode({ alg: 'HS256', typ: 'JWT' }),
+    encode({
+      application_id: 'app-1',
+      consumer_id: 'consumer-1',
+      ...claims,
+    }),
+    'not-a-real-signature',
+  ].join('.');
+};
+
+describe('Vault - Apideck attribution', () => {
+  beforeEach(() => jest.spyOn(window, 'fetch'));
+  beforeEach(() => fetchMock(NO_ADDED_CONNECTIONS_RESPONSE));
+  beforeEach(() => setupIntersectionObserverMock());
+
+  const renderVault = async (
+    claims: Record<string, unknown>,
+    props: Record<string, unknown> = {}
+  ) => {
+    let screen: any;
+    await act(async () => {
+      screen = render(
+        <Vault token={tokenWithClaims(claims)} open {...props} />
+      );
+    });
+    return screen;
+  };
+
+  it('shows the pill for a token with no attribution claim', async () => {
+    const screen = await renderVault({});
+
+    expect(screen.queryByText('Powered by')).toBeInTheDocument();
+  });
+
+  it('shows the pill when the claim says it is not hidden', async () => {
+    const screen = await renderVault({
+      attribution: { hidden: false, hideable: true },
+    });
+
+    expect(screen.queryByText('Powered by')).toBeInTheDocument();
+  });
+
+  it('hides the pill when the claim says it is hidden', async () => {
+    const screen = await renderVault({
+      attribution: { hidden: true, hideable: true },
+    });
+
+    expect(screen.queryByText('Powered by')).not.toBeInTheDocument();
+  });
+
+  // The prop and the claim are independent vetoes for now. Enforcing
+  // entitlement against the prop is a separate follow-up, so an unentitled
+  // caller passing showAttribution={false} must still hide the pill.
+  it('still honours showAttribution={false} when the claim allows the pill', async () => {
+    const screen = await renderVault(
+      { attribution: { hidden: false, hideable: false } },
+      { showAttribution: false }
+    );
+
+    expect(screen.queryByText('Powered by')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Ref apideck-io/unify#9854 — server side is apideck-io/unify#11664.

Vault sessions minted by unify now carry a server-derived claim:

```
attribution: { hidden: boolean, hideable: boolean }
```

`hidden` is true only when the application has the setting enabled **and** the account is entitled, resolved at mint time — so a plan downgrade re-enables attribution on the next session with no migration. `hideable` reports the entitlement itself.

## Changes

- `types/Session.ts` — `attribution` added alongside `data_scopes`
- `Vault.tsx` — forwards `session?.attribution` to `Modal`
- `Modal.tsx` — `show={isOpen && showAttribution && !attribution?.hidden}`

## The prop and the claim are independent vetoes

Mirrors `showConsumer` × `settings.hide_consumer_card` in `ModalContent`: a lower-plan customer passing `showAttribution={false}` still hides the pill. **This PR does not enforce entitlement against the prop** — unify is shipping measurement first so the blast radius can be sized from data. When that decision lands it is a one-line change here, which is what `hideable` exists for.

## Backwards compatibility

Tokens with no `attribution` claim keep showing the pill, so this is safe to release ahead of the unify deploy.

## Verification

`yarn test`: **13/13 suites, 73/73 tests** (was 12/69). Lint 0 errors, build clean, `attribution` present in `dist`.

The new suite was checked for whether it actually discriminates: with the gate and prop fully reverted, exactly the *"hides the pill when the claim says it is hidden"* case fails while the three back-compat and prop-veto cases still pass. (A partial revert was inconclusive — removing only the gate left `attribution` unused and the suite failed to *compile* rather than failing an assertion.)

## Not released yet

No version bump in this PR. `iframe-vault` pins `^0.20.6`, and for `0.x` versions caret allows patch only, so a `0.21.0` minor will not be silently adopted — the consumer bump is a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)