### PR TITLE
feat!: enforce entitlement against the showAttribution prop (Ref #9854)

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -65,6 +65,19 @@ const Modal: any = ({
     setMounted(true);
   }, []);
 
+  // `showAttribution: false` is only honoured when the account is entitled to hide
+  // the badge. Previously the prop and the claim were independent vetoes, so any
+  // plan could suppress attribution from client code.
+  //
+  // Enforcement is deliberately keyed on `hideable === false` — a *positive* signal
+  // that the account is not entitled — rather than on `!hideable`. An absent claim
+  // must keep honouring the prop: unify omits `attribution` entirely for sessions
+  // minted without an account (management sessions), and any deployment older than
+  // the claim sends nothing at all. Treating absent as "not entitled" would make
+  // the prop silently stop working for both.
+  const notEntitled = attribution?.hideable === false;
+  const propSuppressesBadge = showAttribution === false && !notEntitled;
+
   // Close on Escape regardless of where focus currently sits. Headless UI's own
   // Escape handler can fail to fire when the host app's focus is outside the
   // portal, leaving users unable to dismiss with the keyboard.
@@ -162,14 +175,12 @@ const Modal: any = ({
               </div>
             </Transition.Child>
             {/*
-              The prop and the claim are independent vetoes, mirroring
-              showConsumer x settings.hide_consumer_card in ModalContent: a
-              lower-plan customer passing showAttribution={false} still hides the
-              pill. Enforcing entitlement against the prop is a separate,
-              deliberate follow-up, not this change.
+              Hidden when the server says so, or when the caller asked and is
+              entitled to ask. See propSuppressesBadge above for why an absent
+              claim still honours the prop.
             */}
             <Transition
-              show={isOpen && showAttribution && !attribution?.hidden}
+              show={isOpen && !attribution?.hidden && !propSuppressesBadge}
               as={Fragment}
               enter="ease-out duration-300 delay-300"
               enterFrom="opacity-0 translate-y-4"

--- a/test/attribution.test.tsx
+++ b/test/attribution.test.tsx
@@ -71,12 +71,54 @@ describe('Vault - Apideck attribution', () => {
   // The prop and the claim are independent vetoes for now. Enforcing
   // entitlement against the prop is a separate follow-up, so an unentitled
   // caller passing showAttribution={false} must still hide the pill.
-  it('still honours showAttribution={false} when the claim allows the pill', async () => {
-    const screen = await renderVault(
-      { attribution: { hidden: false, hideable: false } },
-      { showAttribution: false }
-    );
+  describe('showAttribution enforcement', () => {
+    // The behaviour change. Previously the prop was an independent veto, so any
+    // plan could suppress the badge from client code.
+    it('ignores showAttribution={false} when the account is not entitled', async () => {
+      const screen = await renderVault(
+        { attribution: { hidden: false, hideable: false } },
+        { showAttribution: false }
+      );
 
-    expect(screen.queryByText('Powered by')).not.toBeInTheDocument();
+      expect(screen.queryByText('Powered by')).toBeInTheDocument();
+    });
+
+    it('honours showAttribution={false} when the account is entitled', async () => {
+      const screen = await renderVault(
+        { attribution: { hidden: false, hideable: true } },
+        { showAttribution: false }
+      );
+
+      expect(screen.queryByText('Powered by')).not.toBeInTheDocument();
+    });
+
+    // Enforcement keys on hideable === false, a positive "not entitled" signal.
+    // unify omits the claim entirely for sessions minted without an account
+    // (management sessions), and older deployments never send it — those must keep
+    // honouring the prop rather than silently having it stop working.
+    it('honours showAttribution={false} when there is no attribution claim', async () => {
+      const screen = await renderVault({}, { showAttribution: false });
+
+      expect(screen.queryByText('Powered by')).not.toBeInTheDocument();
+    });
+
+    it('honours showAttribution={false} when the claim omits hideable', async () => {
+      const screen = await renderVault(
+        { attribution: { hidden: false } },
+        { showAttribution: false }
+      );
+
+      expect(screen.queryByText('Powered by')).not.toBeInTheDocument();
+    });
+
+    // hidden always wins, regardless of the prop.
+    it('keeps the pill hidden when the claim says hidden even with showAttribution={true}', async () => {
+      const screen = await renderVault(
+        { attribution: { hidden: true, hideable: true } },
+        { showAttribution: true }
+      );
+
+      expect(screen.queryByText('Powered by')).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #151 / 0.22.0. Ref apideck-io/unify#9854.

**BREAKING:** `showAttribution: false` is now ignored for accounts not entitled to hide the badge.

0.22.0 shipped the prop and the `attribution` claim as **independent vetoes**, so any plan could suppress attribution from client code — the paywall was bypassable. This closes that.

```diff
- show={isOpen && showAttribution && !attribution?.hidden}
+ show={isOpen && !attribution?.hidden && !propSuppressesBadge}
```

## The subtlety that matters

Enforcement keys on `hideable === false` — a **positive** "not entitled" signal — not on `!hideable`.

That is load-bearing. unify omits the `attribution` claim **entirely** for sessions minted without an account (`CreateManagementSessionUseCase`), and any deployment older than the claim sends nothing at all. Treating an absent claim as "not entitled" would silently stop `showAttribution: false` working for both. So an absent or partial claim still honours the prop.

The original plan proposed a one-liner that had this bug; it would have regressed management sessions.

## Behaviour matrix

| claim | prop | badge | change? |
|---|---|---|---|
| absent | `false` | hidden | unchanged |
| `hideable` omitted | `false` | hidden | unchanged |
| `hideable: true` | `false` | hidden | unchanged |
| **`hideable: false`** | **`false`** | **visible** | **← this PR** |
| `hidden: true` | any | hidden | unchanged |

## Who this affects

Customers on a plan without the entitlement who currently pass `showAttribution={false}`. **Their badge will reappear when they upgrade the package.** That is the intended effect, but it is a visible change to a shipped integration and should get a release note.

## One caveat, stated plainly

The deferred measurement step — telemetry for how many applications pass the prop without entitlement — was **never built** (Phase 10b of the original plan). So this ships with no data on the blast radius. The plan deliberately sequenced measure-then-enforce for that reason; enforcing now is a conscious choice to close the bypass immediately rather than wait.

If you would rather size it first, the alternative is to land the telemetry, watch for a period, then merge this.

## Verification

13/13 suites, 77 tests, lint 0 errors, build clean.

The new tests were checked for discrimination rather than assumed: reverting the gate (including the extracted consts, so it fails an assertion rather than failing to compile) fails **only** the enforcement case while all four back-compat cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)